### PR TITLE
130 Implement new metadata display

### DIFF
--- a/app/assets/stylesheets/ucsc.scss
+++ b/app/assets/stylesheets/ucsc.scss
@@ -337,3 +337,56 @@ div.uv.viewer iframe {
     margin-bottom:0px;
     padding:0;
 }
+
+/* Style single work page */
+#display-work-img {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    padding: 20px 0;
+    text-align: center;
+    background-color: #000;
+    position: relative;
+    .glyph-wrap {
+        position: absolute;
+        bottom: 30px;
+        left: 30px;
+    }
+    .glyphicon {
+        float: left;
+        margin-right:20px;
+        color: #fff;
+        font-size: 200%;
+    }
+}
+
+/* Style works page metadata */
+h2.metadata {
+    font-size: 16px;
+    font-weight: bold;
+    text-transform: uppercase;
+    margin-bottom: 25px;
+}
+table.work.attributes {
+    th {
+        width: 165px;
+        text-align: right;
+        color: #838282;
+        &:after {
+            content: ':';
+        }
+    }
+    th.fix-colon:after {
+        content: '';
+    }
+    ul {
+        margin: 5px 0 5px 15px;
+    }
+}
+#show-more-metadata,
+#hide-more-metadata {
+    display:inline-block;
+    margin: 25px 0 0 180px;
+    &:hover {
+        cursor: pointer;
+    }
+}

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -14,12 +14,13 @@ class WorkIndexer < Hyrax::WorkIndexer
         solr_doc['member_ids_ssim'] = object.ordered_member_ids
         object.ordered_member_ids.each do |member_id|
           next unless (member = SolrDocument.find(member_id)).image?
+          solr_doc["hasRelatedImage_ssim"] ||= []
           case member['has_model_ssim'].first
           when "FileSet"
-            (solr_doc["hasRelatedImage_ssim"] ||= []) << member_id
+            solr_doc["hasRelatedImage_ssim"] << member_id
             (solr_doc["file_set_ids_ssim"] ||= []) << member_id 
           when "Work"
-            (solr_doc["hasRelatedImage_ssim"] ||= []) += member["hasRelatedImage_ssim"]
+            solr_doc["hasRelatedImage_ssim"]  += member["hasRelatedImage_ssim"]
           end
         end
         solr_doc["hasRelatedImage_ssim"] = (solr_doc["hasRelatedImage_ssim"] || []).uniq

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -1,18 +1,20 @@
 <!-- <h2><%= t('.header') %></h2> -->
-<table class="table table-striped <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+<h2 class="metadata">About this item:</h2>
+<table class="<%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
    <tbody>
     <%= render 'primary_attribute_rows', presenter: presenter %>
     <% if  ((can? :manage, Work) or (can? :review, :submissions)) %>
         <%= presenter.attribute_to_html(:masterFilename, {label: "Master Filename"})  %>
         <%= presenter.attribute_to_html(:accessionNumber, {label: "Accession Number"}) %>
     <% end %>
+    <%= render 'relationships', presenter: @presenter %> <%# Moved from show.html.erb to here %>
   </tbody>
 </table>
 
-<button class="more-metadata" onclick="jQuery('.more-metadata').toggle()">Show More</button>
+<span id="show-more-metadata" class="more-metadata" onclick="jQuery('.more-metadata').toggle()"><a>More information +</a></span>
 
 <div class="more-metadata" style="display:none">
-    <table class="table table-striped <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
+    <table class="<%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
         <tbody>
             <%= render 'secondary_attribute_rows', presenter: presenter %>
 
@@ -23,7 +25,7 @@
         </tbody>
     </table>
 
-    <button id="hide-more-metadata" onclick="jQuery('.more-metadata').toggle()">Show less</button>
+    <span id="hide-more-metadata" onclick="jQuery('.more-metadata').toggle()"><a>Show less information -</a></span>
 </div>
 
 <script>

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -1,3 +1,1 @@
-<dl class="work-show">
 <%= render 'relationships_parent_rows', presenter: presenter %>
-</dl>

--- a/app/views/hyrax/base/_relationships_parent_row.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_row.html.erb
@@ -1,0 +1,17 @@
+<%# output changed from definition list to table %>
+<tr>
+  <th class="fix-colon"> <%= t(".label", type: type.humanize) %> </th>
+  <td>
+    <% if items.blank? %>
+      <p><%= t('.empty', type: type.humanize) %></p>
+    <% else %>
+      <ul class="tabular">
+        <% items.each do |item| %>
+          <li class='attribute attribute-title'>
+            <%= link_to item.title.first, url_for_document(item) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -1,0 +1,16 @@
+<%# Render presenters which aren't specified in the 'presenter_types' %>
+<% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
+  <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
+<% end %>
+
+<%# Render grouped presenters. Show rows if there are any items of that type %>
+<% presenter.presenter_types.each do |type| %>
+  <% presenter.grouped_presenters(filtered_by: type).each_pair do |_, items| %>
+    <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
+  <% end %>
+<% end %>
+
+<% if current_user %>
+<%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
+<% end %>
+

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -13,7 +13,6 @@
         <%# = render 'work_description', presenter: @presenter %>
         <%= render 'primary_media', presenter: @presenter, viewer: @presenter.universal_viewer?, av_files: (av_files = @presenter.all_av_files) %>
         <%= render 'metadata', presenter: @presenter %>
-        <%= render 'relationships', presenter: @presenter %>
     </div>
     <div class="col-sm-4">
         <%= render "show_actions", presenter: @presenter %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -42,6 +42,7 @@ en:
           rights_tesim: Rights
           subject_tesim: Subject
           title_tesim: Title
+          admin_set: In Administrative Set
   hyrax:
     product_name: "Digital Assets"
     institution_name:  &INSTITUTION_NAME "UC Santa Cruz"


### PR DESCRIPTION
Resolves [](https://github.com/UCSCLibrary/dams_project_mgmt/issues/130)

- Updates site CSS for metadata header, tables, and buttons.
- Moves rendering of relationships from show.html.erb to metadata.html.erb.
- Removes bootstrap table classes from the metadata table element.
- Changes 'More information' from button element to span+a elements.
- Renders relationships as table elements rather than definition lists.
- Customizes the label for Admin Set to remove the 
![Firefox_Screenshot_2020-01-10T21-53-48 144Z](https://user-images.githubusercontent.com/515412/72189066-bd374c80-33b0-11ea-8c3a-8000d1f5ce3e.png)
extra colon.