### PR TITLE
provide an access token for our image server as a cookie to all visitors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,9 +8,23 @@ class ApplicationController < ActionController::Base
   include Hyrax::Controller
 
   include Hyrax::ThemedLayoutController
-  with_themed_layout '1_column'
 
+  before_action :set_image_token
+
+  with_themed_layout '1_column'
 
   protect_from_forgery with: :exception
   skip_after_action :discard_flash_if_xhr
+
+  private
+
+  def set_image_token
+    return if cookies[:ucsc_imgsrv_token].present?
+    domain = ["production", "staging"].include?(Rails.env) ? '.library.ucsc.edu' : :all
+    expires = Time.now + 86400
+    value = Digest::SHA256.hexdigest(expires.to_i.to_s + ENV['image_token_secret'])
+    cookies[:ucsc_imgsrv_token] ||= {value: "#{expires.to_i.to_s}-#{value}",
+                                     expires: expires,
+                                     domain: domain}
+  end
 end


### PR DESCRIPTION
This is the last step in implementing image authorization for our IIIF image server