### PR TITLE
Download links in modal windows now work, and the download modal now …

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -47,6 +47,7 @@ class FileSet < ActiveFedora::Base
   def image_server_derivative_sizes
     ['90,',
      '!200,150',
+     '250,',
      '!300,300',
      '800,']
   end

--- a/app/presenters/ucsc/work_show_presenter.rb
+++ b/app/presenters/ucsc/work_show_presenter.rb
@@ -18,14 +18,14 @@ module Ucsc
     end
 
     # We should delegate this to the solrDocument, which should have it already indexed (for works at least).
-    def display_image_url
+    def display_image_url(size="800,")
       if representative_id
         return nil unless current_ability.can?(:read, representative_id)
         representative_image = SolrDocument.find(representative_id)
         return nil unless representative_image.image?
-        representative_image.display_image_url
+        representative_image.display_image_url(size: size)
       elsif solr_document.image?
-        solr_document.display_image_url
+        solr_document.display_image_url(size: size)
       end
     end
 

--- a/app/views/hyrax/base/_modals.html.erb
+++ b/app/views/hyrax/base/_modals.html.erb
@@ -1,19 +1,21 @@
-<%# Download %>
-<div class="modal fade" id="downloadWork" tabindex="-1" role="dialog" aria-labelledby="downloadLabel">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-body">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="downloadLabel">Download</h4>
-        <h5>Rights Information:</h5>
-        <p>I'm a test, please don't copy me.</p>
-        <ul>
-          <li><a href="">Download Small (250px)</a></li>
-          <li><a href="">Download Large (1000px)</a></li>
-          <li><a href="">Download Small (250px) + Citation (Zip File)</a></li>
-          <li><a href="">Download Large (1000px) + Citation (Zip File)</a></li>
-        </ul>
+<% if @presenter.image? %>
+  <%# Download %>
+  <div class="modal fade" id="downloadWork" tabindex="-1" role="dialog" aria-labelledby="downloadLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-body">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="downloadLabel">Download</h4>
+          <h5>Rights Information:</h5>
+          <p>Not currently available.</p>
+          <ul>
+            <li><%= link_to('Download Small (250px)',@presenter.display_image_url("250,")) %></li>
+            <li><%= link_to('Download Small (1000px)',@presenter.display_image_url("1000,")) %></li>
+            <li><a href="">Download Small (250px) + Citation (Zip File)</a></li>
+            <li><a href="">Download Large (1000px) + Citation (Zip File)</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -17,8 +17,10 @@
         </div>
         <div class="col-sm-6">
             <div id="download-share-cite">
-                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#downloadWork">
+                <% if @presenter.image? %>
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#downloadWork">
                     <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download</button>
+                <% end %>
             </div>
         </div>
     </div>


### PR DESCRIPTION
…only appears on image works.

Resolves [126 - Download 250px](https://github.com/UCSCLibrary/dams_project_mgmt/issues/126) and [127 - Download 1000px](https://github.com/UCSCLibrary/dams_project_mgmt/issues/127)

Code Changes:
- Adds 250px width to the caching defaults on the image server.
- Adds a parameter to the display_image_url method to specify a size.
- Wraps the download button and modal window in an "If work is an image" conditional.
- Makes the download links actually work.

![Firefox_Screenshot_2020-02-20T21-58-44 635Z](https://user-images.githubusercontent.com/515412/74983013-10f27800-53ea-11ea-8727-4437dc0f54c2.png)
