### PR TITLE
Detail links now work on mobile browsers, by fixing bootstrap layout classes

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -3,28 +3,30 @@
 <%= render 'shared/citations' %>
 
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
-    <div class="col-xs-12">
+    <div class="col-sm-12">
         <header>
             <%= render 'work_title', presenter: @presenter %>
         </header>
     </div>
 
-    <div class="col-xs-12">
-        <%# = render 'work_description', presenter: @presenter %>
-        <%= render 'primary_media', presenter: @presenter, viewer: @presenter.universal_viewer?, av_files: (av_files = @presenter .all_av_files) %>
-        <div class="col-sm-6">
-            <%= render 'metadata', presenter: @presenter %>
-        </div>
-        
-        <%# if @presenter.image?  %>
-        <% if false %>
+    <div class="col-sm-12">
+        <div class="row">
+            <%# = render 'work_description', presenter: @presenter %>
+            <%= render 'primary_media', presenter: @presenter, viewer: @presenter.universal_viewer?, av_files: (av_files = @presenter .all_av_files) %>
             <div class="col-sm-6">
-                <div id="download-share-cite">
-                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#downloadWork">
-                        <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download</button>
-                </div>
+                <%= render 'metadata', presenter: @presenter %>
             </div>
-        <% end  %>
+        
+            <%# if @presenter.image?  %>
+            <% if false %>
+                <div class="col-sm-6">
+                    <div id="download-share-cite">
+                        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#downloadWork">
+                            <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download</button>
+                    </div>
+                </div>
+            <% end  %>
+        </div>
     </div>
     <div class="col-sm-4">
         <%= render "show_actions", presenter: @presenter %>


### PR DESCRIPTION
Resolves [218 - Mobile links bug](https://github.com/UCSCLibrary/dams_project_mgmt/issues/218)

Changes:
- Corrected the bootstrap layout classes and added a missing row div.