### PR TITLE
Aria label added to search form field.

### DIFF
--- a/app/views/catalog/_targeted_search_form.html.erb
+++ b/app/views/catalog/_targeted_search_form.html.erb
@@ -8,7 +8,7 @@
 
         <% searchable_fields =  ScoobySnacks::METADATA_SCHEMA.searchable_fields.unshift ScoobySnacks::Field.new('all_fields', {'label' => "All Fields"}) %>
         <% search_field_options = options_from_collection_for_select(searchable_fields, :name, :label, "all_fields") %>
-        <%= select_tag('search_field', search_field_options,) %>
+        <%= select_tag('search_field', search_field_options, {"aria-label" => "Select the field to search"}) %>
         <div class="input-group">
             <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 


### PR DESCRIPTION
Resolves [#261 DAMS Field Select Box Needs Description](https://github.com/UCSCLibrary/dams_project_mgmt/issues/261).

Changes: Adds an Aria-label attribute to the select dropdown for "search field" on the main search form.

No relevant screenshots - this is for screen readers.