### PR TITLE
Implement collection landing page description box.

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -456,17 +456,6 @@ div.uv.viewer iframe {
     padding:0;
 }
 
-/* Collection landing page */
-#collection-description {
-    background-color: #f7f7f7;
-    padding: 1em;
-    margin-bottom: 30px;
-    h1 {
-        margin: 0;
-    }
-}
-
-
 /* Single work page */
 #display-work-img {
     width: 100vw;
@@ -673,6 +662,25 @@ table.work.attributes {
 }
 
 /* Collection Landing page & Search Results page(?) */
+header#collection-description {
+    display: block;
+    overflow: hidden;
+    margin-bottom: 30px;
+    padding: 1em;
+    background-color: #f7f7f7;
+    h1 {
+        margin: 0;
+    }
+    .col-md-9 {
+        padding-top: 15px;
+        height: 250px;
+        a {
+            position: absolute;
+            bottom: 10px;
+            right: 15px;
+        }
+    }
+}
 .hyc-bl-results #documents { 
     clear: both !important; 
     .document {

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,2 +1,3 @@
 class CollectionsController < Hyrax::CollectionsController
+	self.presenter_class = Ucsc::CollectionPresenter
 end

--- a/app/presenters/ucsc/collection_presenter.rb
+++ b/app/presenters/ucsc/collection_presenter.rb
@@ -3,5 +3,12 @@ module Ucsc
     def permission_badge_class
       Ucsc::PermissionBadge
     end
+
+    def related_resource
+      if solr_document.relatedResource.present?
+        return solr_document.relatedResource
+      end
+    end
+
   end
 end

--- a/app/views/hyrax/collections/_collection_description.html.erb
+++ b/app/views/hyrax/collections/_collection_description.html.erb
@@ -1,0 +1,8 @@
+<% presenter.description.each do |description| %>
+  <%= simple_format(auto_link(description)) %>
+<% end %>
+<% if presenter.related_resource %>
+	<%= link_to presenter.related_resource do %>
+		Visit the collection guide <span class='glyphicon glyphicon-arrow-right' aria-hidden='true'></span>
+	<% end %>
+<% end %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -4,17 +4,17 @@
     <div class="col-md-12">
 
       <% unless @presenter.banner_file.blank? %>
-          <header id="collection-description" class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+          <header id="collection-description" class="hyc-banner row" style="background-image:url(<%= @presenter.banner_file %>)">
       <% else %>
-          <header id="collection-description">
+          <header id="collection-description" class="row">
       <% end %>
 
-      <div class="hyc-title">
+      <div class="hyc-title col-md-12">
         <h1><%= @presenter.title.first %></h1>
       </div>
 
       <% unless @presenter.logo_record.blank? %>
-          <div class="hyc-logos">
+          <div class="hyc-logos col-md-3">
             <% @presenter.logo_record.each_with_index  do |lr, i| %>
 
                 <% if lr[:linkurl].blank? %>
@@ -28,9 +28,12 @@
             <% end %>
           </div>
       <% end %>
-
-      <%= render 'collection_description', presenter: @presenter %>
-
+      <div class="col-md-3">
+        <%= render 'hyrax/collections/media_display', presenter: @presenter %>
+      </div>
+      <div class="col-md-9">
+        <%= render 'collection_description', presenter: @presenter %>
+      </div>
       </header>
 
     </div>


### PR DESCRIPTION
Resolves [#222 collection description box](https://github.com/UCSCLibrary/dams_project_mgmt/issues/222)

- Extends Hyrax collection presenter with the UCSC version.
- Adds a related_resource method to the UCSC collection presenter.
- Customizes the collection description partial to add a link to the guide.
- Styles the page with bootstrap classes and a bit of custom css.

![Firefox_Screenshot_2020-09-17T23-37-21 861Z](https://user-images.githubusercontent.com/515412/93538892-18d4b500-f904-11ea-8a9e-849e5973d7cc.png)
