### PR TITLE
Resolves 369, thumbnails no longer skewed.

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -688,7 +688,6 @@ header#collection-description {
     }
     .thumbnail a > img {
         background-color: #f7f7f7;
-        min-height: 225px;
     }
 }
 


### PR DESCRIPTION
Resolves [369 Landing page thumbnail issue](https://github.com/UCSCLibrary/dams_project_mgmt/issues/369)

Changes:
- Removes css line that caused the skewing.

Screenshot:
![Uploading Firefox_Screenshot_2020-10-09T16-25-11.589Z.png…]()
