### PR TITLE
Hide view options on collection landing page and search results pages.

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -719,12 +719,20 @@ header#collection-description {
     #sort-dropdown {
         margin-right: .7em;
     }
+    .view-type {
+        display: none;
+    }
     @media (min-width: $screen-sm) {
         #per_page-dropdown { display: inline-block; }
     }
     @media (min-width: $screen-md) {
-        .view-type { display: inline-block; }
+        .view-type { 
+            /* display: inline-block; */
+        }
     }
+}
+#sortAndPerPage .view-type {
+    display: none;
 }
 
 /* Search within collection */


### PR DESCRIPTION
Resolves [380 Hide list, masonry and slideshow browse views](https://github.com/UCSCLibrary/dams_project_mgmt/issues/380) and partially resolves [371 Remove thumbnail view options](https://github.com/UCSCLibrary/dams_project_mgmt/issues/371)

Using CSS, hides the view-type element on collection landing pages and search results pages.

![Firefox_Screenshot_2020-10-19T23-01-40 434Z](https://user-images.githubusercontent.com/515412/96520674-66ef1800-1224-11eb-9dee-2f0c1bd64b39.png)
