### PR TITLE
Style titles for search results pages

### DIFF
--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -1,0 +1,3 @@
+$(document).ready(function() {
+  $('[data-toggle="tooltip"]').tooltip()
+});

--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -854,6 +854,7 @@ div#documents.gallery {
     }
     .thumbnail {
         border: none;
+        position: relative;
         a > img,
         span.fa {
             background-color: #f7f7f7;
@@ -866,6 +867,22 @@ div#documents.gallery {
         .documentHeader .index-document-functions {
             display: none;
         }
+        .tooltip {
+            margin: 90% 0 0 0;
+            padding: 0 20px;
+            pointer-events: none;
+        }
+        h3 .tooltip {
+            margin: -10.2% 0 0 0;
+            padding: 0 30px;
+        }
+        .tooltip.in { opacity: 1; }
+        .tooltip-inner {
+            background-color: #f7f7f7;
+            color: #000;
+            opacity: 1;
+        }
+        .tooltip-arrow { display: none; }
     }
 }
 

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,0 +1,8 @@
+<div class="document col-xs-6 col-md-3">
+  <div class="thumbnail">
+    <%= render_thumbnail_tag(document, {'data-toggle' => 'tooltip', 'title' => document.title.first}, :counter => document_counter_with_offset(document_counter)) %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,3 +1,5 @@
+<%# Customized from Blacklight Gallery 0.12.0 %>
+<%# Add tooltips to thumbnails %>
 <div class="document col-xs-6 col-md-3">
   <div class="thumbnail">
     <%= render_thumbnail_tag(document, {'data-toggle' => 'tooltip', 'title' => document.title.first}, :counter => document_counter_with_offset(document_counter)) %>

--- a/app/views/catalog/_index_header_gallery_default.html.erb
+++ b/app/views/catalog/_index_header_gallery_default.html.erb
@@ -16,7 +16,7 @@
         <%= t('blacklight.search.documents.counter', counter: counter) %>
       </span>
     <% end %>
-    <%= link_to_document document, document.title.first, counter: counter %>
+    <%= link_to_document document, truncate(document.title.first, length: 40, separator: ' '), {counter: counter, "data-toggle" => 'tooltip', 'title' => document.title.first} %>
   </h3>
   <%= document_actions %>
 </header>


### PR DESCRIPTION
Resolves [249 - Style Titles for Search Results](https://github.com/UCSCLibrary/dams_project_mgmt/issues/249).

Code changes:
- New js file to enable bootstrap tooltips. app/assets/javascripts/tooltips.js 
- New view partial to customize Blacklight gallery by adding tooltips.  app/views/catalog/_index_gallery.html.erb 
- Update app/views/catalog/_index_header_gallery_default.html.erb to truncate title and add tooltip.
- CSS styling for tooltips.

Screenshot:
![249-titles](https://user-images.githubusercontent.com/515412/101848440-595e5c00-3b0a-11eb-96f9-1651f12df105.png)
