### PR TITLE
Breadcrumb style

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -538,6 +538,13 @@ body {
     }
 }
 
+/* Breadcrumbs */
+nav.breadcrumb {
+    background-color: transparent;
+    border: none;
+    padding-left: 0;
+}
+
 /* Footer */
 footer {
     padding: 20px;

--- a/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/hyrax/bootstrap_breadcrumbs_builder.rb
@@ -1,0 +1,27 @@
+# Customized from Hyrax 2.9
+# Removes a truncate() in the render_element function
+class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Builder
+  include ActionView::Helpers::OutputSafetyHelper
+
+  def render
+    return "" if @elements.blank?
+
+    @context.content_tag(:nav, breadcrumbs_options) do
+      @context.content_tag(:ol) do
+        safe_join(@elements.uniq.collect { |e| render_element(e) })
+      end
+    end
+  end
+
+  def render_element(element)
+    html_class = 'active' if @context.current_page?(compute_path(element)) || element.options["aria-current"] == "page"
+
+    @context.content_tag(:li, class: html_class) do
+      @context.link_to_unless(html_class == 'active', compute_name(element), compute_path(element), element.options)
+    end
+  end
+
+  def breadcrumbs_options
+    { class: 'breadcrumb', role: "region", "aria-label" => "Breadcrumb" }
+  end
+end

--- a/app/builders/ucsc/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/ucsc/bootstrap_breadcrumbs_builder.rb
@@ -1,7 +1,6 @@
-# Customized from Hyrax 2.9
-# Removes a truncate() in the render_element function
-class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Builder
-  include ActionView::Helpers::OutputSafetyHelper
+# This class extends its Hyrax equivalent to remove some truncation functions
+# This extension added while using Hyrax 2.9
+class Ucsc::BootstrapBreadcrumbsBuilder < Hyrax::BootstrapBreadcrumbsBuilder
 
   def render
     return "" if @elements.blank?
@@ -21,7 +20,4 @@ class Hyrax::BootstrapBreadcrumbsBuilder < BreadcrumbsOnRails::Breadcrumbs::Buil
     end
   end
 
-  def breadcrumbs_options
-    { class: 'breadcrumb', role: "region", "aria-label" => "Breadcrumb" }
-  end
 end

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -1,0 +1,34 @@
+<%# Customized from Hyrax 2.9 %>
+<%# Uses customized breadcrumbs builder %> 
+<!DOCTYPE html>
+<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+  <head>
+    <%= render partial: 'layouts/head_tag_content' %>
+    <%= content_for(:head) %>
+  </head>
+
+  <body>
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content" %>
+    </div>
+    <%= render '/masthead' %>
+    <%= content_for(:navbar) %>
+    <%= content_for(:precontainer_content) %>
+    <div id="content-wrapper" class="container" role="main">
+      <%= render '/flash_msg' %>
+      <%= render_breadcrumbs builder: Ucsc::BootstrapBreadcrumbsBuilder %>
+      <% if content_for?(:page_header) %>
+        <div class="row">
+          <div class="col-xs-12 main-header">
+            <%= yield(:page_header) %>
+          </div>
+        </div>
+      <% end %>
+
+      <a name="skip-to-content" id="skip-to-content"></a>
+      <%= content_for?(:content) ? yield(:content) : yield %>
+    </div><!-- /#content-wrapper -->
+    <%= render 'shared/footer' %>
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -1,0 +1,39 @@
+<%# Customized from Hyrax 2.9 %>
+<%# Uses custom Breadcrumb Builder %<
+<!DOCTYPE html>
+<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+  <head>
+    <%= render partial: 'layouts/head_tag_content' %>
+    <%= content_for(:head) %>
+  </head>
+
+  <body class="dashboard">
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content" %>
+    </div>
+    <%= render '/masthead' %>
+    <%= content_for(:navbar) %>
+    <div id="content-wrapper" role="main">
+      <div class="sidebar maximized">
+        <%= render 'hyrax/dashboard/sidebar' %>
+      </div>
+      <div class="main-content maximized">
+        <%= render_breadcrumbs builder: Ucsc::BootstrapBreadcrumbsBuilder %>
+        <%= render '/flash_msg' %>
+        <% if content_for?(:page_header) %>
+          <div class="row">
+            <div class="col-xs-12 main-header">
+              <%= yield(:page_header) %>
+            </div>
+          </div>
+        <% end %>
+
+          <a name="skip-to-content" id="skip-to-content"></a>
+          <%= content_for?(:content) ? yield(:content) : yield %>
+
+      </div>
+
+    </div><!-- /#content-wrapper -->
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -1,5 +1,5 @@
 <%# Customized from Hyrax 2.9 %>
-<%# Uses custom Breadcrumb Builder %<
+<%# Uses custom Breadcrumb Builder %>
 <!DOCTYPE html>
 <html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
   <head>

--- a/lib/ucsc/breadcrumbs_for_works.rb
+++ b/lib/ucsc/breadcrumbs_for_works.rb
@@ -6,6 +6,8 @@ module Ucsc
 
       hide_breadcrumbs = true;
 
+      add_breadcrumb "Digital Collections", root_path
+
       begin
         if (col = presenter.member_of_collection_presenters.first).present?
           add_breadcrumb col.title.first, "/records/#{col.id}"


### PR DESCRIPTION
Resolves [40 - Apply new breacrumb style](https://github.com/UCSCLibrary/dams_project_mgmt/issues/40).

Code changes:
- Customizes app/builders/hyrax/bootstrap_breadcrumbs_builder.rb, removes truncate function
- Adds root path breadcrumb to lib/ucsc/breadcrumbs_for_works.rb 
- A few CSS styling rules

Screenshot:
![Firefox_Screenshot_2020-12-15T22-54-09 039Z](https://user-images.githubusercontent.com/515412/102282400-68b41f80-3ee5-11eb-90ab-ca5587324f30.png)
