### PR TITLE
Javascript bug fix

### DIFF
--- a/app/assets/javascripts/citations.js
+++ b/app/assets/javascripts/citations.js
@@ -19,7 +19,7 @@ function copyCitation(citation) {
   }
 }
 
-$( document ).ready(function() {
+$(document).on('turbolinks:load', function() {
 
   // Add tooltips to the buttons, and click event listeners
   $('#citeWork').find('.btn').each(function(){

--- a/app/assets/javascripts/embed.js
+++ b/app/assets/javascripts/embed.js
@@ -7,7 +7,7 @@ function updateEmbedCode(uri, w, h, script) {
   document.getElementById("embedCode").value = embedTemplate;
 }
 
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
   // Set default size and initalize iframe dimensions
   $('#embedSize').val('small');
   var selected = $('#embedSize').find(':selected');

--- a/app/assets/javascripts/facets.js
+++ b/app/assets/javascripts/facets.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
 	$("button.facets-toggle").click(function() {
 		$(".facets-toggle span.text").text(function(i, text){
 			return text === "Show Filters" ? "Hide Filters" : "Show Filters";

--- a/app/assets/javascripts/homepage.js
+++ b/app/assets/javascripts/homepage.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
 	$("#view-all-collections").click(function() {
 		$("#all-collections").toggle(1000);
 		$(this).text(function(i, text){

--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -1,3 +1,3 @@
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
   $('[data-toggle="tooltip"]').tooltip()
 });


### PR DESCRIPTION
Resolves [423 - View all collections button doesn't work if someone uses the "browse collections link"](https://github.com/UCSCLibrary/dams_project_mgmt/issues/423).

Traced this one back to the document.ready function. This function doesn't fire when turbolinks loads the page, and so all instances of $(document).ready have been replaced with the $(document).on('turbolinks:load') instead.