### PR TITLE
ENV variable for image_server

### DIFF
--- a/stack_car/.env
+++ b/stack_car/.env
@@ -8,3 +8,4 @@ MYSQL_PASSWORD=potentialmidday
 FEDORA_URL=http://fcrepo:8080/rest
 SOLR_TEST_URL=http://index:8983/solr/hyrax-test
 SOLR_URL=http://index:8983/solr/hyrax
+image_token_secret=123


### PR DESCRIPTION
Setting the ENV variable for image_token_secret resolves several rspec failing tests.