### PR TITLE
Fix indexed controlled fields

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -24,43 +24,21 @@ class CollectionIndexer < Hyrax::CollectionIndexer
       # index the field that bulkrax uses to keep track of imported/exported records
       solr_doc[Solrizer.solr_name('bulkrax_identifier', :facetable)] = object.bulkrax_identifier
 
-
-      # index custom fields
+      # index custom, non-controlled fields
       solr_doc[Solrizer.solr_name('collectionCallNumber', :stored_searchable)] = object.collectionCallNumber
-
       solr_doc[Solrizer.solr_name('extent', :stored_searchable)] = object.extent
-
       solr_doc[Solrizer.solr_name('donorProvenance', :stored_searchable)] = object.donorProvenance
-
       solr_doc[Solrizer.solr_name('harmfulLanguageStatement')] = object.harmfulLanguageStatement
-
       solr_doc[Solrizer.solr_name('publisherHomepage', :stored_searchable)] = object.publisherHomepage
-
       solr_doc[Solrizer.solr_name('rightsStatement', :stored_searchable)] = object.rightsStatement
-
-      solr_doc[Solrizer.solr_name('rightsHolder', :stored_searchable)] = object.rightsHolder
-
       solr_doc[Solrizer.solr_name('rightsStatus', :stored_searchable)] = object.rightsStatus
-
       solr_doc[Solrizer.solr_name('accessRights', :stored_searchable)] = object.accessRights
-
-      solr_doc[Solrizer.solr_name('subjectName', :stored_searchable)] = object.subjectName
-
-      solr_doc[Solrizer.solr_name('subjectPlace', :stored_searchable)] = object.subjectPlace
-
-      solr_doc[Solrizer.solr_name('subjectTopic', :stored_searchable)] = object.subjectTopic
-
-      solr_doc[Solrizer.solr_name('subjectTitle', :stored_searchable)] = object.subjectTitle
-
       solr_doc[Solrizer.solr_name('dateCreatedDisplay')] = object.dateCreatedDisplay
-
       # end custom fields indexing
-
     end
   end
 
   def schema
     ScoobySnacks::METADATA_SCHEMA
   end
-  
 end


### PR DESCRIPTION
# Summary

Do not override indexing of controlled fields - they get indexed by `#index_controlled_fields`

Fixes `spec/models/collection_spec.rb`