### PR TITLE
i29 Add support for importing controlled fields with Bulkrax

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_dependency Bulkrax::Engine.root.join('app', 'factories', 'bulkrax', 'object_factory').to_s
+
+Bulkrax::ObjectFactory.class_eval do
+  def permitted_attributes
+    additional_attrs = %i[
+      id
+      edit_users
+      edit_groups
+      read_groups
+      visibility
+      work_members_attributes
+      admin_set_id
+      member_of_collections_attributes
+    ]
+    # OVERRIDE: permit controlled field attribute hashes
+    ::ScoobySnacks::METADATA_SCHEMA.controlled_field_names.each do |field_name|
+      additional_attrs << "#{field_name}_attributes".to_sym
+    end
+
+    klass.properties.keys.map(&:to_sym) + additional_attrs
+  end
+  private :permitted_attributes
+end

--- a/app/indexers/controlled_indexer_behavior.rb
+++ b/app/indexers/controlled_indexer_behavior.rb
@@ -121,14 +121,11 @@ module ControlledIndexerBehavior
         when String
           # This is just a normal string (from a legacy model, etc)
           # Go ahead and create a new entry in the appropriate local vocab, if there is one
-          if (local_vocab = field.vocabularies.find{|vocab| vocab['authority'].to_s.downcase == 'local'}).is_a?(Hash)
-            auth_name = local_vocab['subauthority']
-            mintLocalAuthUrl(auth_name, val) if auth_name.present?
-            label = val
-          else
-            #If have a random string and no local vocab, just move on for now
-            next
-          end
+          subauth_name = get_subauthority_for(field: field, authority_name: 'local')
+          next unless subauth_name.present? # If have a random string and no local vocab, just move on for now
+
+          mint_local_auth_url(subauth_name, val) if subauth_name.present?
+          label = val
         else
           raise ArgumentError, "Can't handle #{val.class} as a metadata term"
         end
@@ -140,19 +137,23 @@ module ControlledIndexerBehavior
     solr_doc
   end
 
-  private 
+  def get_subauthority_for(field:, authority_name:)
+    field_vocab = field.vocabularies.find { |vocab| vocab['authority'].to_s.downcase == authority_name }
+    return unless field_vocab.present?
 
-  def mintLocalAuthUrl(auth_name, value) 
+    field_vocab['subauthority']
+  end
+
+  def mint_local_auth_url(subauth_name, value)
     id = value.parameterize
-    auth = Qa::LocalAuthority.find_or_create_by(name: auth_name)
-    entry = Qa::LocalAuthorityEntry.find_or_create_by(local_authority: auth,
-                                                      label: value,
-                                                      uri: id)
-    return localIdToUrl(id,auth_name)
+    auth = Qa::LocalAuthority.find_or_create_by(name: subauth_name)
+    Qa::LocalAuthorityEntry.find_or_create_by(local_authority: auth,
+                                              label: value,
+                                              uri: id)
+    local_id_to_url(id, subauth_name)
   end
 
-  def localIdToUrl(id,auth_name) 
-    return "#{CatalogController.root_url}/authorities/show/local/#{auth_name}/#{id}"
+  def local_id_to_url(id, subauth_name)
+    "#{CatalogController.root_url}/authorities/show/local/#{subauth_name}/#{id}"
   end
-
 end

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -1,11 +1,65 @@
 # frozen_string_literal: true
 
 module Bulkrax::HasLocalProcessing
+  include ControlledIndexerBehavior
+
+  SOURCES_OF_AUTHORITIES = {
+    # local db, faster
+    ::Qa::Authorities::Local => 'local',
+    # remote, slower
+    ::Qa::Authorities::Loc => 'loc',
+    ::Qa::Authorities::Getty => 'getty'
+  }.freeze
+
   # This method is called during build_metadata
   # add any special processing here, for example to reset a metadata property
   # to add a custom property from outside of the import data
   def add_local
-    self.parsed_metadata.delete('rights_statement')
-    self.parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']] if override_rights_statement || self.parsed_metadata['rightsStatement'].blank?
+    parsed_metadata.delete('rights_statement')
+    if override_rights_statement || parsed_metadata['rightsStatement'].blank?
+      parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']]
+    end
+
+    add_controlled_fields
+  end
+
+  # Controlled fields expect an ActiveTriples instance as a value. Bulkrax only imports strings.
+  # Use the imported string values to lookup or create valid ActiveTriples URIs and add them
+  # to the Entry's parsed_metadata in the format that the actor stack expects.
+  def add_controlled_fields
+    metadata_schema = ::ScoobySnacks::METADATA_SCHEMA
+
+    metadata_schema.controlled_field_names.each do |field_name|
+      field = metadata_schema.get_field(field_name)
+      parsed_metadata.delete(field_name) # remove non-standardized values
+      next if raw_metadata[field_name.downcase].blank?
+
+      raw_metadata[field_name.downcase].split(/\s*[|]\s*/).uniq.each_with_index do |value, i|
+        auth_id = value if value.match?(::URI::DEFAULT_PARSER.make_regexp) # assume raw, user-provided URI is a valid authority
+        auth_id ||= search_authorities_for_id(field, value)
+        auth_id ||= create_local_authority_id(field, value)
+        next unless auth_id.present?
+
+        parsed_metadata["#{field_name}_attributes"] ||= {}
+        parsed_metadata["#{field_name}_attributes"][i] = { 'id' => auth_id }
+      end
+    end
+  end
+
+  # @return [String, nil] URI for authority, or nil if one could not be found
+  def search_authorities_for_id(field, value)
+    SOURCES_OF_AUTHORITIES.each do |auth_source, auth_name|
+      subauth_name = get_subauthority_for(field: field, authority_name: auth_name)
+      next unless subauth_name.present?
+
+      subauthority = auth_source.subauthority_for(subauth_name)
+      subauthority.search(value)&.first&.dig('id')
+    end
+  end
+
+  # @return [String, nil] URI for local authority, or nil if one could not be created
+  def create_local_authority_id(field, value)
+    local_subauth_name = get_subauthority_for(field: field, authority_name: 'local')
+    mint_local_auth_url(local_subauth_name, value) if local_subauth_name.present?
   end
 end


### PR DESCRIPTION
# README

## https://github.com/UCSCLibrary/ucsc-library-digital-collections/pull/219 must be merged first

#### These changes are dependent on changes in https://github.com/UCSCLibrary/ucsc-library-digital-collections/pull/219 (namely, the `Gemfile.lock` change), so that PR should be reviewed/merged before this one 

---

Ref https://gitlab.com/notch8/ucsc-library-digital-collections/-/issues/29 

# Acceptance Criteria

- [ ] Importing a valid URI into a controlled field does not break the work's edit page 
- [ ] Importing a string into a controlled field does not break the work's edit page 
- [ ] On the work's show page, controlled fields display their human-readable label 
  - E.g. when importing `http://www.geonames.org/5393052` into `subjectPlace`, [the show page should display "Santa Cruz"](https://share.getcloudapp.com/DOu6YONo) 

# Testing Instructions 

1. Download this CSV of sample data: [Object Types - Ingest Spreadsheet.csv](https://github.com/UCSCLibrary/ucsc-library-digital-collections/files/7771466/Object.Types.-.Ingest.Spreadsheet.csv)  
2. Login to [staging](http://ucsc-hyrax-staging.notch8.cloud) as an admin<sup>1</sup>. Navigate to Dashboard > Importers 
3. Click the New button. Fill out all the required fields. Upload the CSV from Step 1. Click "Create and Import" 
4. Locate one of the newly imported works.<sup>2</sup> Navigate to the work's public-facing show page 
5. Validate that the populated controlled fields<sup>3</sup> display the human-readable label (see [Acceptance Criteria](#acceptance-criteria) for an example) 
6. Navigate to the work's edit page. Validate that no errors are thrown. Validate that controlled field values render correctly ([example](https://share.getcloudapp.com/xQuj5rl0)) 
7. Repeat steps 4-6 for at least two more times 

<sup>1</sup> Admin credentials: see [ticket](https://gitlab.com/notch8/ucsc-library-digital-collections/-/issues/29) or ask in Slack 

<sup>2</sup> Works can be located through the entries on the importer show page, via Dashboard > Works, or by performing a search from the homepage 

<sup>3</sup> List of controlled fields
<details><summary>Expand</summary>

```
creator
contributor
resourceType
rightsHolder
subjectName
subjectPlace
subjectTemporal
subjectTitle
subjectTopic
physicalFormat
language
genre
```

</details> 