### PR TITLE
Symlink Bulkrax tmp/ directories to shared directory

### DIFF
--- a/lib/capistrano/tasks/link-stream.rake
+++ b/lib/capistrano/tasks/link-stream.rake
@@ -11,6 +11,24 @@ namespace :hycruz  do
       env = (fetch(:stage).to_s == 'staging') ? "production" : fetch(:stage)
       print "creating temp folder if necessary..."
       execute "mkdir -p #{current_path}/tmp"
+      print "Linking temp imports folder..."
+      execute "rm -f #{current_path}/tmp/imports || true"
+      execute "ln -s /dams_derivatives/tmp/#{env}/imports #{current_path}/tmp/imports"
+    end
+    on roles(:ingest,:app), in: :sequence, wait: 5 do
+      set :rails_env, fetch(:stage)
+      env = (fetch(:stage).to_s == 'staging') ? "production" : fetch(:stage)
+      print "creating temp folder if necessary..."
+      execute "mkdir -p #{current_path}/tmp"
+      print "Linking temp exports folder..."
+      execute "rm -f #{current_path}/tmp/exports || true"
+      execute "ln -s /dams_derivatives/tmp/#{env}/exports #{current_path}/tmp/exports"
+    end
+    on roles(:ingest,:app), in: :sequence, wait: 5 do
+      set :rails_env, fetch(:stage)
+      env = (fetch(:stage).to_s == 'staging') ? "production" : fetch(:stage)
+      print "creating temp folder if necessary..."
+      execute "mkdir -p #{current_path}/tmp"
       print "Linking temp upload folder..."
       execute "rm -f #{current_path}/tmp/uploads || true"
       execute "ln -s /dams_derivatives/tmp/#{env}/uploads #{current_path}/tmp/uploads"


### PR DESCRIPTION
On the sandbox server, imports keep failing with the following error: 

```
Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/imports/8_20220126211059/OT_simple.csv
```

even though the mentioned file exists at the correct location. This seems to be because Sidekiq is running on a separate "ingest" server, which does not have access to the files uploaded by Bulkrax. 

On deploy, symlink required bulkrax tmp directories to shared directory so it can be accessed by the ingest server