### PR TITLE
Bulkrax - do not raise `Date.parse` error when importing blank `dateCreated` values

### DIFF
--- a/app/indexers/sortable_field_indexer_behavior.rb
+++ b/app/indexers/sortable_field_indexer_behavior.rb
@@ -5,6 +5,8 @@ module SortableFieldIndexerBehavior
     schema.sortable_fields.each do |field|
       if field.input == "date"
         next unless (date_string = Array(solr_doc[field.solr_name]).first)
+        next if date_string.blank?
+
         if date_string.to_s.match?(/\A[12][0-9]{3}[-\/][0-9]{1,2}\z/)
           year, month = date_string.split(/[-\/]/).map(&:to_i)
           date = Date.new(year,month)

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -15,17 +15,26 @@ module Bulkrax::HasLocalProcessing
   # add any special processing here, for example to reset a metadata property
   # to add a custom property from outside of the import data
   def add_local
-    parsed_metadata['rightsStatement'] = parsed_metadata.delete('rights_statement')
-    if override_rights_statement || parsed_metadata['rightsStatement'].blank?
-      parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']]
-    end
-
+    remap_rights_statement
     add_controlled_fields
+    remap_resource_type
+  end
 
+  private
+
+  # TODO: Remove after ScoobySnacks is removed -- rightsStatement will no longer exist
+  def remap_rights_statement
+    parsed_metadata['rightsStatement'] = parsed_metadata.delete('rights_statement')
+    return unless override_rights_statement || parsed_metadata['rightsStatement'].blank?
+
+    parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']]
+  end
+
+  # TODO: Rename "resourceType_attributes" to "resource_type_attributes" after
+  # ScoobySnacks is removed -- resourceType will no longer exist
+  def remap_resource_type
     return unless is_a?(Bulkrax::CsvFileSetEntry)
 
-    # TODO: This needs to be removed after ScoobySnacks is
-    # taken out because resourceType shouldn't exist after that
     parsed_metadata.delete('resourceType_attributes')
     parsed_metadata['resource_type'] = raw_metadata['resourcetype'].split(/\s*[|]\s*/)
   end

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -16,8 +16,8 @@ module Bulkrax::HasLocalProcessing
   # to add a custom property from outside of the import data
   def add_local
     remap_rights_statement
-    add_controlled_fields
     remap_resource_type
+    add_controlled_fields
   end
 
   private


### PR DESCRIPTION
The source of this bug ended up being in a custom parser, not Bulkrax. This PR includes some cleanup in the `HasLocalProcessing` concern for legibility 