### PR TITLE
Fix BrowseEverything modal JS bug

### DIFF
--- a/app/views/bulkrax/importers/_browse_everything.html.erb
+++ b/app/views/bulkrax/importers/_browse_everything.html.erb
@@ -1,0 +1,3 @@
+<%# OVERRIDE FILE from Bulkrax v2.2.3 %>
+<%# OVERRIDE: render custom button %>
+<%= render 'shared/browse_everything_button', model_param: form.object.model_name.param_key, obj_id: form.object.id %>

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -1,0 +1,59 @@
+<%# OVERRIDE FILE from Hyrax v2.9.6 to fix BrowseEverything button JS %>
+     <div id="fileupload">
+        <!-- Redirect browsers with JavaScript disabled to the origin page -->
+        <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
+        <!-- The table listing the files available for upload/download -->
+        <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
+        <% if Hyrax.config.browse_everything? %>
+          <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
+        <% else %>
+          <%= t('hyrax.base.form_files.local_upload_html') %>
+        <% end %>
+        <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+        <div class="fileupload-buttonbar">
+          <div class="row">
+            <div class="col-xs-12">
+                <!-- The fileinput-button span is used to style the file input field as button -->
+                <span id="addfiles" class="btn btn-success fileinput-button">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span>Add files...</span>
+                    <input type="file" name="files[]" multiple />
+                </span>
+                <!-- The fileinput-button span is used to style the file input field as button -->
+                <span id="addfolder" class="btn btn-success fileinput-button">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span>Add folder...</span>
+                    <input type="file" name="files[]" multiple directory webkitdirectory />
+                </span>
+                <% if Hyrax.config.browse_everything? %>
+                  <%# OVERRIDE: render custom button %>
+                  <%= render 'shared/browse_everything_button', model_param: f.object.model.model_name.param_key, obj_id: f.object.model.id %>
+                <% end %>
+                <button type="reset" id="file-upload-cancel-btn" class="btn btn-warning cancel hidden">
+                    <span class="glyphicon glyphicon-ban-circle"></span>
+                    <span>Cancel upload</span>
+                </button>
+                <!-- The global file processing state -->
+                <span class="fileupload-process"></span>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-12">
+              <!-- The global progress state -->
+              <div class="fileupload-progress fade">
+                  <!-- The global progress bar -->
+                  <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                      <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+                  </div>
+                  <!-- The extended global progress state -->
+                  <div class="progress-extended">&nbsp;</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="dropzone">
+          <%= t('hyrax.base.form_files.dropzone') %>
+        </div>
+     </div>
+
+<%= render 'hyrax/uploads/js_templates' %>

--- a/app/views/shared/_browse_everything_button.erb
+++ b/app/views/shared/_browse_everything_button.erb
@@ -1,0 +1,31 @@
+<%#
+    Fixes a bug where the BrowseEverything modal never closes, breaking the page.
+    Add BrowseEverything "Upload Cloud Files" button inspired by Hyrax's:
+    https://github.com/samvera/hyrax/blob/v2.9.6/app/views/hyrax/base/_form_files.html.erb#L28-L33
+    Also, includes a jQuery script to ensure modal closes properly.
+  %>
+<%# Bulkrax and Hyrax have different ID selectors %>
+<% btn_id = "#{model_param == 'importer' ? 'browse' : 'browse-btn' }" %>
+<%= button_tag(type: 'button', class: 'btn btn-success', id: btn_id) do %>
+  <span class='glyphicon glyphicon-plus'></span>
+  <%= t('hyrax.upload.browse_everything.browse_files_button') %>
+<% end %>
+<script>
+  ;(function() {
+    $(document).ready(function() {
+        $("button#<%= btn_id %>").browseEverything({
+         route: "<%= browse_everything_engine.root_path %>",
+         target: "<%= obj_id.present? ? "#edit_#{model_param}_#{obj_id}" : "#new_#{model_param}" %>"
+       }).done(function(data) {
+         $('.ev-browser.show').removeClass('show')
+         // User has submitted files; data contains an array of URLs and their options
+       }).cancel(function() {
+         $('.ev-browser.show').removeClass('show')
+         // User cancelled the browse operation
+       }).fail(function(status, error, text) {
+         $('.ev-browser.show').removeClass('show')
+         // URL retrieval experienced a technical failure
+       });
+    })
+  })();
+</script>


### PR DESCRIPTION
Add BrowseEverything button partial with custom JS; override Hyrax and Bulkrax views to use custom BE button. 

With this change, Cloud Files are functional when using Bulkrax to import records. However, using BE through the UI does not set up files correctly (although it still fixes the problem where the modal never closes) 