### PR TITLE
Bulkrax - collection creation bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ gem 'scooby_snacks', git: 'https://github.com/UCSCLibrary/ScoobySnacks.git'
 gem 'bulk_ops', git: 'https://github.com/UCSCLibrary/BulkOps.git', branch: 'master'
 
 # Bulkrax
-gem 'bulkrax', '~> 2.2'
+gem 'bulkrax', '~> 2.3'
 # gem 'bulkrax', path: 'vendor/engines/bulkrax'
 gem 'willow_sword', github: 'notch8/willow_sword'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (2.2.0)
+    bulkrax (2.3.0)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)
@@ -998,7 +998,7 @@ DEPENDENCIES
   blacklight_oai_provider (>= 6.0.0)
   browse-everything
   bulk_ops!
-  bulkrax (~> 2.2)
+  bulkrax (~> 2.3)
   bundler (>= 2)
   byebug
   capistrano

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,7 +101,6 @@ ActiveRecord::Schema.define(version: 2022_01_19_213325) do
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
     t.integer "import_attempts", default: 0
-    t.index ["importerexporter_id"], name: "index_bulkrax_entries_on_importerexporter_id"
   end
 
   create_table "bulkrax_exporter_runs", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|


### PR DESCRIPTION
Bump Bulkrax version to ~> 2.3. This resolves the following [bug](https://github.com/samvera-labs/bulkrax/issues/417): 

> If a Collection entry fails during Import, it halts the processing of all following Collection entries

Closes https://github.com/UCSCLibrary/dams_project_mgmt/issues/502 