### PR TITLE
i499 Do not fill in blank rights statements when importing

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -15,20 +15,21 @@ module Bulkrax::HasLocalProcessing
   # add any special processing here, for example to reset a metadata property
   # to add a custom property from outside of the import data
   def add_local
-    remap_rights_statement
     remap_resource_type
     add_controlled_fields
   end
 
-  private
-
-  # TODO: Remove after ScoobySnacks is removed -- rightsStatement will no longer exist
-  def remap_rights_statement
+  # OVERRIDE: Don't fill in blank rights statements. Allow them to be blank.
+  # Only override rights_statement if the user chose to override them in
+  # the Importer form.
+  def add_rights_statement
+    # OVERRIDE: Remap rights_statement to rightsStatement. Possibly remove this
+    # after ScoobySnacks is removed (rightsStatement may become rights_statement then)
     parsed_metadata['rightsStatement'] = parsed_metadata.delete('rights_statement')
-    return unless override_rights_statement || parsed_metadata['rightsStatement'].blank?
-
-    parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']]
+    parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']] if override_rights_statement
   end
+
+  private
 
   # TODO: Rename "resourceType_attributes" to "resource_type_attributes" after
   # ScoobySnacks is removed -- resourceType will no longer exist

--- a/spec/factories/bulkrax_entries.rb
+++ b/spec/factories/bulkrax_entries.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# OVERRIDE FILE from Bulkrax v2.3.0 to access Bulkrax factories in UCSC specs
+
+FactoryBot.define do
+  factory :bulkrax_entry, class: 'Bulkrax::Entry' do
+    identifier { "MyString" }
+    type { 'Bulkrax::Entry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { "MyText" }
+    parsed_metadata { "MyText" }
+  end
+
+  factory :bulkrax_csv_entry, class: 'Bulkrax::CsvEntry' do
+    identifier { "csv_entry" }
+    type { 'Bulkrax::CsvEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+
+  factory :bulkrax_csv_entry_work, class: 'Bulkrax::CsvEntry' do
+    identifier { "entry_work" }
+    type { 'Bulkrax::CsvEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+
+  factory :bulkrax_csv_entry_collection, class: 'Bulkrax::CsvEntry' do
+    identifier { "entry_collection" }
+    type { 'Bulkrax::CsvCollectionEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+
+  factory :bulkrax_csv_entry_failed, class: 'Bulkrax::CsvEntry' do
+    identifier { "entry_failed" }
+    type { 'Bulkrax::CsvEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { { title: 'Title' } }
+    parsed_metadata { {} }
+    statuses { [association(:bulkrax_status, status_message: 'Failed')] }
+  end
+
+  factory :bulkrax_rdf_entry, class: 'Bulkrax::RdfEntry' do
+    identifier { "MyString" }
+    type { 'Bulkrax::RdfEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+
+  factory :bulkrax_csv_entry_file_set, class: 'Bulkrax::CsvFileSetEntry' do
+    identifier { 'file_set_entry_1' }
+    type { 'Bulkrax::CsvFileSetEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+
+  trait :with_file_set_metadata do
+    raw_metadata do
+      {
+        'title' => 'FileSet Entry',
+        'source_identifier' => 'file_set_entry_1',
+        'file' => 'removed.png'
+      }
+    end
+  end
+end

--- a/spec/factories/bulkrax_importers.rb
+++ b/spec/factories/bulkrax_importers.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# OVERRIDE FILE from Bulkrax v2.3.0 to access Bulkrax factories in UCSC specs
+
+FactoryBot.define do
+  factory :bulkrax_importer, class: 'Bulkrax::Importer' do
+    name { "A.N. Import" }
+    admin_set_id { "MyString" }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::OaiDcParser" }
+    limit { 10 }
+    parser_fields do
+      {
+        'base_url' => 'http://commons.ptsem.edu/api/oai-pmh',
+        'metadata_prefix' => 'oai_dc'
+      }
+    end
+    field_mapping { [{}] }
+  end
+
+  factory :bulkrax_importer_oai, class: 'Bulkrax::Importer' do
+    name { 'Oai Collection' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::OaiDcParser' }
+    limit { 10 }
+    parser_fields do
+      {
+        'base_url' => 'http://commons.ptsem.edu/api/oai-pmh',
+        'metadata_prefix' => 'oai_dc'
+      }
+    end
+    field_mapping { { 'identifier' => { from: ['identifier'], source_identifier: true } } }
+  end
+
+  factory :bulkrax_importer_csv, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/good.csv' } }
+    field_mapping { {} }
+    after :create, &:current_run
+
+    trait :with_relationships_mappings do
+      field_mapping do
+        {
+          'parents' => { 'from' => ['parents_column'], split: /\s*[|]\s*/, related_parents_field_mapping: true },
+          'children' => { 'from' => ['children_column'], split: /\s*[|]\s*/, related_children_field_mapping: true }
+        }
+      end
+    end
+  end
+
+  factory :bulkrax_importer_csv_complex, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/complex.csv' } }
+    field_mapping { {} }
+  end
+
+  factory :bulkrax_importer_bagit, class: 'Bulkrax::Importer' do
+    name { 'Bagit Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::BagitParser' }
+    limit { 10 }
+    parser_fields do
+      {
+        'import_file_path' => 'spec/fixtures/bags/bag',
+        'metadata_file_name' => 'descMetadata.nt',
+        'metadata_format' => 'Bulkrax::RdfEntry'
+      }
+    end
+    field_mapping { { 'source_identifier' => { from: ['source_identifier'], source_identifier: true } } }
+    after :create, &:current_run
+  end
+
+  factory :bulkrax_importer_csv_bad, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/bad.csv' } }
+    field_mapping { {} }
+  end
+
+  factory :bulkrax_importer_csv_failed, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/failed.csv' } }
+    field_mapping { {} }
+  end
+
+  factory :bulkrax_importer_xml, class: 'Bulkrax::Importer' do
+    name { 'XML Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:admin) } # OVERRIDE: replace :base_user with :admin
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::XmlParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/xml/good.xml' } }
+    field_mapping do
+      {
+        'title': { from: ['TitleLargerEntity'] },
+        'abstract': { from: ['Abstract'] },
+        'source' => { from: ['DrisUnique'], source_identifier: true }
+      }
+    end
+  end
+end

--- a/spec/models/concerns/has_local_processing_spec.rb
+++ b/spec/models/concerns/has_local_processing_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::HasLocalProcessing do
+  let(:entry) { build(:bulkrax_csv_entry) }
+
+  describe '#add_local' do
+    it 'calls #remap_resource_type' do
+      expect(entry).to receive(:remap_resource_type)
+      entry.add_local
+    end
+
+    it 'calls #add_controlled_fields' do
+      expect(entry).to receive(:add_controlled_fields)
+      entry.add_local
+    end
+  end
+
+  describe '#add_rights_statement' do
+    before do
+      entry.parsed_metadata = { 'rights_statement' => 'http://rightsstatements.org/vocab/InC/1.0/' }
+    end
+
+    it 'remaps rights_statement to rightsStatement' do
+      expect(entry.parsed_metadata['rights_statement']).to eq('http://rightsstatements.org/vocab/InC/1.0/')
+      expect(entry.parsed_metadata['rightsStatement']).to be_nil
+
+      entry.add_rights_statement
+
+      expect(entry.parsed_metadata['rights_statement']).to be_nil
+      expect(entry.parsed_metadata['rightsStatement']).to eq('http://rightsstatements.org/vocab/InC/1.0/')
+    end
+
+    context 'when a record is imported without a rights statement' do
+      before do
+        entry.parsed_metadata = { 'title' => 'No Rights Statement' }
+      end
+
+      it 'does not fall back on a default rights statement' do
+        expect(entry.parsed_metadata['rightsStatement']).to be_nil
+
+        entry.add_rights_statement
+
+        expect(entry.parsed_metadata['rightsStatement']).to be_nil
+      end
+    end
+
+    context 'when a record is imported with a blank rights statement' do
+      before do
+        entry.parsed_metadata = { 'title' => 'Blank Rights Statement', 'rights_statement' => '' }
+      end
+
+      it 'does not fall back on a default rights statement' do
+        expect(entry.parsed_metadata['rightsStatement']).to be_blank
+
+        entry.add_rights_statement
+
+        expect(entry.parsed_metadata['rightsStatement']).to be_blank
+      end
+    end
+
+    context 'when an importer is configured to override rights statements' do
+      before do
+        allow(entry).to receive(:override_rights_statement).and_return(true)
+        allow(entry.parser).to receive(:parser_fields).and_return({ 'rights_statement' => 'http://rightsstatements.org/vocab/InC/1.0/' })
+      end
+
+      context 'when a record is imported without a rights statement' do
+        before do
+          entry.parsed_metadata = { 'title' => 'No Rights Statement' }
+        end
+
+        it 'falls back on a default rights statement' do
+          expect(entry.parsed_metadata['rightsStatement']).to be_nil
+
+          entry.add_rights_statement
+
+          expect(entry.parsed_metadata['rightsStatement']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+        end
+      end
+
+      context 'when a record is imported with a blank rights statement' do
+        before do
+          entry.parsed_metadata = { 'title' => 'Blank Rights Statement', 'rights_statement' => '' }
+        end
+
+        it 'falls back on a default rights statement' do
+          expect(entry.parsed_metadata['rightsStatement']).to be_blank
+
+          entry.add_rights_statement
+
+          expect(entry.parsed_metadata['rightsStatement']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/UCSCLibrary/dams_project_mgmt/issues/499 

- Do not fill in blank rights statements
  - Only fill in blank rights statements if selecting "Override rights statements" on the importer 
- Condense rights statement overrides 
- Specs 
  - Bring over a couple spec factories from Bulkrax 