### PR TITLE
i498 Add dateCreatedIngest property, update predicates

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -78,7 +78,11 @@ module Hyrax
 
       property :subjectTitle, predicate: ::RDF::Vocab::MODS.subjectTitle
 
+      property :dateCreated, predicate: ::RDF::Vocab::BF2.creationDate
+
       property :dateCreatedDisplay, predicate: ::RDF::Vocab::MODS.dateCreated  
+
+      property :dateCreatedIngest, predicate: ::RDF::Vocab::DC.created  
 
       id_blank = proc { |attributes| attributes[:id].blank? }
 

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -327,7 +327,7 @@ fields:
     definition: Date of creation of the original resource.
     encoding: W3CDTF
     label: 'Date Created'
-    predicate: DC:date
+    predicate: BF2:creationDate
     data_type: date
     index_itemprop: dateCreated
     input: date
@@ -345,6 +345,11 @@ fields:
       - editor_primary 
       - search_result
     predicate: MODS:dateCreated  
+
+  dateCreatedIngest:
+    predicate: DC:created
+    definition: Date of creation of the original resource.
+    label: 'Date Created Ingest'
 
   dateOfSituation:
     definition: A date of a situation depicted in the work or associated with the subject of the work.

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -41,5 +41,27 @@ RSpec.describe 'Collection', type: :model do
     collection.save
     expect(Collection.find(collection.id).visibility).to eq("request")
   end
-  
+
+  describe 'predicates' do
+    context '#dateCreated' do
+      it 'is BF2:creationDate' do
+        expect(work.send(:properties)['dateCreated'].predicate.to_s)
+          .to eq('http://id.loc.gov/ontologies/bibframe/creationDate')
+      end
+    end
+
+    context '#dateCreatedDisplay' do
+      it 'is MODS:dateCreated' do
+        expect(work.send(:properties)['dateCreatedDisplay'].predicate.to_s)
+          .to eq('http://www.loc.gov/mods/rdf/v1#dateCreated')
+      end
+    end
+
+    context '#dateCreatedIngest' do
+      it 'is DC:created' do
+        expect(work.send(:properties)['dateCreatedIngest'].predicate.to_s)
+          .to eq('http://purl.org/dc/terms/created')
+      end
+    end
+  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -143,5 +143,27 @@ RSpec.describe Work do
   it "can link to its associated solr document" do
     expect(work.solr_doc).to be_a(SolrDocument)
   end
-  
+
+  describe 'predicates' do
+    context '#dateCreated' do
+      it 'is BF2:creationDate' do
+        expect(work.send(:properties)['dateCreated'].predicate.to_s)
+          .to eq('http://id.loc.gov/ontologies/bibframe/creationDate')
+      end
+    end
+
+    context '#dateCreatedDisplay' do
+      it 'is MODS:dateCreated' do
+        expect(work.send(:properties)['dateCreatedDisplay'].predicate.to_s)
+          .to eq('http://www.loc.gov/mods/rdf/v1#dateCreated')
+      end
+    end
+
+    context '#dateCreatedIngest' do
+      it 'is DC:created' do
+        expect(work.send(:properties)['dateCreatedIngest'].predicate.to_s)
+          .to eq('http://purl.org/dc/terms/created')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/498 

- Add `dateCreatedIngest` property 
- Update predicates to match updates in the [data dictionary](https://docs.google.com/spreadsheets/d/1q2xrxULg6whSHYxXeirz7KnghEb_xCMPvW6x_wdo9aU/edit#gid=1359124498) 
- Specs for predicates 