### PR TITLE
i498 Use dateCreatedIngest to index dateCreated

### DIFF
--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -6,8 +6,16 @@ module Hyrax
     
     include ScoobySnacks::WorkFormBehavior
 
+    # OVERRIDE: Do not handle dateCreatedIngest in form; it is for ingest purposes only
+    self.terms -= [:dateCreatedIngest]
+
     self.terms.each do |term|
       delegate term, to: :model
+    end
+
+    # OVERRIDE: Do not display dateCreatedIngest input in form; it is for ingest purposes only
+    def secondary_terms
+      super - [:dateCreatedIngest]
     end
 
 # OVERRIDE FILE from ScoobySnacks to fix unpermitted_params error when saving a new work / Sara G. & Summer

--- a/app/indexers/sortable_field_indexer_behavior.rb
+++ b/app/indexers/sortable_field_indexer_behavior.rb
@@ -1,25 +1,66 @@
+# frozen_string_literal: true
+
 module SortableFieldIndexerBehavior
   extend ActiveSupport::Concern
 
-  def index_sortable_fields solr_doc
+  def index_sortable_fields(solr_doc)
     schema.sortable_fields.each do |field|
-      if field.input == "date"
-        next unless (date_string = Array(solr_doc[field.solr_name]).first)
-        next if date_string.blank?
-
-        if date_string.to_s.match?(/\A[12][0-9]{3}[-\/][0-9]{1,2}\z/)
-          year, month = date_string.split(/[-\/]/).map(&:to_i)
-          date = Date.new(year,month)
-        elsif date_string.to_s.match?(/\A[12][0-9]{3}\z/)
-          date = Date.new(date_string.to_i)
-        else
-          date = Date.parse(date_string)
-        end
-        solr_doc[field.solr_sort_name] = date.strftime('%FT%TZ')
+      if field.name == 'dateCreated' && solr_doc[schema.get_field('dateCreatedIngest').solr_name].present?
+        index_from_ingested_value(field, solr_doc)
+      elsif field.input == 'date'
+        index_date_input(field, solr_doc)
       else
         solr_doc[field.solr_sort_name] = Array(solr_doc[field.solr_name]).first
       end
     end
+
     solr_doc
+  end
+
+  private
+
+  def index_from_ingested_value(sortable_field, solr_doc)
+    ingest_field = schema.get_field('dateCreatedIngest')
+
+    solr_doc[ingest_field.solr_name].each do |value|
+      unless valid_ingested_date?(value)
+        # TODO: raise error instead?
+        Rails.logger.warn(%("#{value}" is not a valid date value for dateCreatedIngest, skipping indexing...))
+        next
+      end
+
+      sortable_date = if value.match?(/^\d{4}$/)
+                        "12-31-#{value}"
+                      elsif value.match?(/^\d{4}-\d{2}-\d{2}$/) || value.match?(/^\d{2}-\d{2}-\d{4}$/)
+                        value
+                      end
+
+      solr_doc[sortable_field.solr_sort_name] << Date.parse(sortable_date).strftime('%FT%TZ')
+    end
+  end
+
+  # Match only thefollowing date formats:
+  # - YYYY
+  # - YYYY-MM-DD
+  # - MM-DD-YYYY
+  def valid_ingested_date?(value)
+    value.match?(/^\d{4}$/) ||
+      value.match?(/^\d{4}-\d{2}-\d{2}$/) ||
+      value.match?(/^\d{2}-\d{2}-\d{4}$/)
+  end
+
+  def index_date_input(field, solr_doc)
+    next unless (date_string = Array(solr_doc[field.solr_name]).first)
+    next if date_string.blank?
+
+    if date_string.to_s.match?(/\A[12][0-9]{3}[-\/][0-9]{1,2}\z/)
+      year, month = date_string.split(/[-\/]/).map(&:to_i)
+      date = Date.new(year,month)
+    elsif date_string.to_s.match?(/\A[12][0-9]{3}\z/)
+      date = Date.new(date_string.to_i)
+    else
+      date = Date.parse(date_string)
+    end
+    solr_doc[field.solr_sort_name] = date.strftime('%FT%TZ')
   end
 end

--- a/app/indexers/sortable_field_indexer_behavior.rb
+++ b/app/indexers/sortable_field_indexer_behavior.rb
@@ -1,68 +1,25 @@
-# frozen_string_literal: true
-
 module SortableFieldIndexerBehavior
   extend ActiveSupport::Concern
 
-  def index_sortable_fields(solr_doc)
+  def index_sortable_fields solr_doc
     schema.sortable_fields.each do |field|
-      if field.name == 'dateCreated' && solr_doc[ingest_field.solr_name].present?
-        index_from_ingested_value(field, solr_doc)
-      elsif field.input == 'date'
-        index_date_input(field, solr_doc)
+      if field.input == "date"
+        next unless (date_string = Array(solr_doc[field.solr_name]).first)
+        next if date_string.blank?
+
+        if date_string.to_s.match?(/\A[12][0-9]{3}[-\/][0-9]{1,2}\z/)
+          year, month = date_string.split(/[-\/]/).map(&:to_i)
+          date = Date.new(year,month)
+        elsif date_string.to_s.match?(/\A[12][0-9]{3}\z/)
+          date = Date.new(date_string.to_i)
+        else
+          date = Date.parse(date_string)
+        end
+        solr_doc[field.solr_sort_name] = date.strftime('%FT%TZ')
       else
         solr_doc[field.solr_sort_name] = Array(solr_doc[field.solr_name]).first
       end
     end
-
     solr_doc
-  end
-
-  private
-
-  def index_from_ingested_value(sortable_field, solr_doc)
-    solr_doc[ingest_field.solr_name].each do |value|
-      value = value.dup.strip
-      unless valid_ingested_date?(value)
-        # TODO: raise error instead?
-        Rails.logger.warn(%("#{value}" is not a valid date value for dateCreatedIngest, skipping indexing...))
-        next
-      end
-
-      sortable_date = if value.match?(/^\d{4}$/)
-                        "#{value}-12-31"
-                      elsif value.match?(/^\d{4}-\d{2}-\d{2}$/)
-                        value
-                      end
-
-      solr_doc[sortable_field.solr_sort_name] ||= []
-      solr_doc[sortable_field.solr_sort_name] << Date.parse(sortable_date).strftime('%FT%TZ')
-    end
-  end
-
-  # Match only thefollowing date formats:
-  # - YYYY
-  # - YYYY-MM-DD
-  def valid_ingested_date?(value)
-    value.match?(/^\d{4}$/) ||
-      value.match?(/^\d{4}-\d{2}-\d{2}$/)
-  end
-
-  def index_date_input(field, solr_doc)
-    return unless (date_string = Array(solr_doc[field.solr_name]).first)
-    return if date_string.blank?
-
-    if date_string.to_s.match?(/\A[12][0-9]{3}[-\/][0-9]{1,2}\z/)
-      year, month = date_string.split(/[-\/]/).map(&:to_i)
-      date = Date.new(year,month)
-    elsif date_string.to_s.match?(/\A[12][0-9]{3}\z/)
-      date = Date.new(date_string.to_i)
-    else
-      date = Date.parse(date_string)
-    end
-    solr_doc[field.solr_sort_name] = date.strftime('%FT%TZ')
-  end
-
-  def ingest_field
-    schema.get_field('dateCreatedIngest')
   end
 end

--- a/app/indexers/sortable_field_indexer_behavior.rb
+++ b/app/indexers/sortable_field_indexer_behavior.rb
@@ -21,7 +21,7 @@ module SortableFieldIndexerBehavior
 
   def index_from_ingested_value(sortable_field, solr_doc)
     solr_doc[ingest_field.solr_name].each do |value|
-      value.strip!
+      value = value.dup.strip
       unless valid_ingested_date?(value)
         # TODO: raise error instead?
         Rails.logger.warn(%("#{value}" is not a valid date value for dateCreatedIngest, skipping indexing...))
@@ -34,6 +34,7 @@ module SortableFieldIndexerBehavior
                         value
                       end
 
+      solr_doc[sortable_field.solr_sort_name] ||= []
       solr_doc[sortable_field.solr_sort_name] << Date.parse(sortable_date).strftime('%FT%TZ')
     end
   end

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -49,7 +49,7 @@ module Bulkrax::HasLocalProcessing
       next if value.blank?
 
       sortable_date = if value.match?(/^\d{4}$/)
-                        "#{value}-12-31"
+                        "#{value}-12-31" # sort YYYY dates at the end of their year
                       elsif value.match?(/^\d{4}-\d{2}-\d{2}$/)
                         value
                       else
@@ -57,7 +57,7 @@ module Bulkrax::HasLocalProcessing
                       end
 
       parsed_metadata['dateCreated'] ||= []
-      parsed_metadata['dateCreated'] << Date.parse(sortable_date).strftime('%FT%TZ')
+      parsed_metadata['dateCreated'] << Date.parse(sortable_date).to_s
     end
   end
 

--- a/app/views/hyrax/base/_secondary_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_secondary_attribute_rows.html.erb
@@ -1,6 +1,7 @@
 <%#= Custom file %>
 <% ScoobySnacks::METADATA_SCHEMA.secondary_display_fields.each do |field| %>
     <% next if (field.name == "dateCreated") && !presenter.attribute_to_html(:dateCreatedDisplay, label: "Date Created").blank? %>
+    <% next if field.name == 'dateCreatedIngest' %>
 
     <% if (html = presenter.attribute_to_html(field.name.to_sym, field.display_options)).present? %>
         <%= html %>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -53,6 +53,7 @@ Bulkrax.setup do |config|
       'creator' => { from: ['creator'], split: /\s*[|]\s*/ },
       'dateCreated' => { from: ['datecreated'], split: /\s*[|]\s*/ },
       'dateCreatedDisplay' => { from: ['datecreateddisplay'], split: /\s*[|]\s*/ },
+      'dateCreatedIngest' => { from: ['datecreatedingest'], split: /\s*[|]\s*/ },
       'dateDigitized' => { from: ['datedigitized'], split: /\s*[|]\s*/ },
       'dateOfSituation' => { from: ['dateofsituation'], split: /\s*[|]\s*/ },
       'datePublished' => { from: ['datepublished'], split: /\s*[|]\s*/ },


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/498 

- [x] Imports can be completed with dateCreatedIngest in formats of YYYY-MM-DD or YYYY.
- [x] Works display only the value in dateCreatedDisplay to end users.
- [x] Exports preserve the format that works were ingested with (ie a YYYY never becomes a YYYY-MM-DD).
- [x] YYYY dates are sorted at the end of the sorted year.