### PR TITLE
Add small delay when minting local auths

### DIFF
--- a/app/indexers/controlled_indexer_behavior.rb
+++ b/app/indexers/controlled_indexer_behavior.rb
@@ -158,6 +158,7 @@ module ControlledIndexerBehavior
                                                 uri: id)
     rescue ActiveRecord::RecordNotUnique => e
       retry_count += 1
+      sleep 0.5
       retry_count <= 5 ? retry : raise(e)
     end
 


### PR DESCRIPTION
Add slight delay when minting local auths to avoid `RecordNotUnique` errors 

![Show Entry Digital Collections Online 2022-03-23 at 8 36 20 AM](https://user-images.githubusercontent.com/32469930/159737442-fbdecb0f-6e7e-4c49-9476-11fa93cbbd26.jpg)
