### PR TITLE
Fix ActiveTriples::UndefinedPropertyError for Collection properties

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,15 +5,9 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include ::Bulkrax::Metadata
 
-  include ::ScoobySnacks::WorkModelBehavior
-
   include Hyrax::Serializers
   include GlobalID::Identification
   include Hyrax::WithEvents
-
-  # Scoobisnacks brings these properties in to the collection, but they are not used
-  # need an empty writer so that adding a work to the collection does not throw an exception
-  attr_writer :label, :relative_path, :import_url
 
   self.indexer = ::CollectionIndexer
 

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -84,11 +84,28 @@ module Hyrax
 
       property :dateCreatedIngest, predicate: ::RDF::Vocab::DC.created  
 
+      property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
+      property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
+      property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
+
+      schema = ScoobySnacks::METADATA_SCHEMA
+      schema.fields.values.each do |field|
+        # Define the property and its indexing unless it is already defined (e.g. in hyrax core)
+        unless respond_to? field.name.to_sym
+          property field.name.to_sym, {predicate: field.predicate, multiple: field.multiple?}  do |index| 
+            index.as *field.solr_descriptors
+            index.type field.solr_data_type
+          end
+        end
+      end
+
       id_blank = proc { |attributes| attributes[:id].blank? }
 
       class_attribute :controlled_properties
-      self.controlled_properties = [:based_near]
-      accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+      self.controlled_properties = schema.controlled_field_names.map(&:to_sym) | [:based_near]
+      self.controlled_properties.each do |controlled_property|
+        accepts_nested_attributes_for controlled_property, reject_if: id_blank, allow_destroy: true
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary 

[ScoobySnacks::WorkModelBehavior](https://github.com/UCSCLibrary/ScoobySnacks/blob/master/lib/scooby_snacks/work_model_behavior.rb#L23) calls `#accepts_nested_attributes_for`, which finalizes the metadata schema, which causes two issues: 

1. All properties added after `include ScoobySnacks::WorkModelBehavior` will throw `UndefinedPropertyError`s 
2. `Hyrax::BasicMetadata` _also_ calls `#accepts_nested_attributes_for`, leading to a conflict 

Instead of fixing the bug in ScoobySnacks, I opted to fix it in this repo since we'll need to bring the change over anyways once the ScoobySnacks gem is removed from the project 