### PR TITLE
Fix RecordNotUnique error when minting local authorities

### DIFF
--- a/app/indexers/controlled_indexer_behavior.rb
+++ b/app/indexers/controlled_indexer_behavior.rb
@@ -149,17 +149,11 @@ module ControlledIndexerBehavior
 
   def mint_local_auth_url(subauth_name, value)
     id = value.parameterize
-    retry_count = 0
+    auth = Qa::LocalAuthority.find_or_create_by(name: subauth_name)
 
-    begin
-      auth = Qa::LocalAuthority.find_or_create_by(name: subauth_name)
-      Qa::LocalAuthorityEntry.find_or_create_by(local_authority: auth,
-                                                label: value,
-                                                uri: id)
-    rescue ActiveRecord::RecordNotUnique => e
-      retry_count += 1
-      sleep 0.5
-      retry_count <= 5 ? retry : raise(e)
+    Qa::LocalAuthorityEntry.find_or_create_by!(uri: id) do |entry|
+      entry.local_authority = auth
+      entry.label = value
     end
 
     local_id_to_url(id, subauth_name)


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/513 

Local authorities are indexed on unique URIs, so only call `#find_or_create_by!` on the URI 