### PR TITLE
update firefox and gecko driver to latest versions

### DIFF
--- a/stack_car/Dockerfile
+++ b/stack_car/Dockerfile
@@ -29,14 +29,14 @@ RUN apt-get -qq update \
                                               yarn \
                                               zip 
 
-ARG FIREFOX_VERSION=58.0.2
+ARG FIREFOX_VERSION=latest
 RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
    && rm -rf /opt/firefox \
    && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
    && rm /tmp/firefox.tar.bz2 \
    && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
    && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
-ARG GK_VERSION=v0.19.1
+ARG GK_VERSION=latest
 RUN wget --no-verbose -O /tmp/geckodriver.tar.gz http://github.com/mozilla/geckodriver/releases/download/$GK_VERSION/geckodriver-$GK_VERSION-linux64.tar.gz \
    && rm -rf /opt/geckodriver \
    && tar -C /opt -zxf /tmp/geckodriver.tar.gz \


### PR DESCRIPTION
The firefox and geckodriver on Dockerfile are outdated, causing the jenkins build to fail.