### PR TITLE
528 description neighborhood import/export/display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -119,6 +119,7 @@ class CatalogController < ApplicationController
 
     ScoobySnacks::BlacklightConfiguration.add_show_fields(config)
     config.add_show_field solr_name("subject", :stored_searchable), label: "Subject"
+    config.add_show_field solr_name("descriptionNeighborhood", :stored_searchable), label: "Neighborhood"
 #    config.add_show_field solr_name("titleDisplay"), label: "Title"
     config.add_show_field solr_name("callNumber"), label: "Call Number"
 

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -82,11 +82,15 @@ module Hyrax
 
       property :dateCreatedDisplay, predicate: ::RDF::Vocab::MODS.dateCreated  
 
-      property :dateCreatedIngest, predicate: ::RDF::Vocab::DC.created  
+      property :dateCreatedIngest, predicate: ::RDF::Vocab::DC.created
 
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
+
       property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
+
       property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
+
+      property :descriptionNeighborhood, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#descriptionNeighborhood'), multiple: false
 
       schema = ScoobySnacks::METADATA_SCHEMA
       schema.fields.values.each do |field|

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -90,7 +90,7 @@ module Hyrax
 
       property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
 
-      property :descriptionNeighborhood, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#descriptionNeighborhood'), multiple: false
+      property :descriptionNeighborhood, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#descriptionNeighborhood')
 
       schema = ScoobySnacks::METADATA_SCHEMA
       schema.fields.values.each do |field|

--- a/app/presenters/ucsc/work_show_presenter.rb
+++ b/app/presenters/ucsc/work_show_presenter.rb
@@ -4,6 +4,7 @@ module Ucsc
 
     delegate :file_set_ids, :image?, :audio?, to: :solr_document
     delegate :titleAlternative, :subseries, :series, to: :solr_document
+    delegate :descriptionNeighborhood, to: :solr_document
 
     self.collection_presenter_class = Ucsc::CollectionPresenter
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -15,6 +15,7 @@
 <%= presenter.attribute_to_html(:physicalDescription, render_as: :faceted, label: "Physical Description") %>
 <%= presenter.attribute_to_html(:donorProvenance, label: "Donor / Provenance" ) %>
 <%= presenter.attribute_to_html(:physicalLocation, render_as: :faceted, label: "Physical Location") %>
+<%= presenter.attribute_to_html(:descriptionNeighborhood, label: "Neighborhood") %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -59,6 +59,7 @@ Bulkrax.setup do |config|
       'datePublished' => { from: ['datepublished'], split: /\s*[|]\s*/, join: true },
       'description' => { from: ['description'], split: /\s*[|]\s*/, join: true },
       'descriptionAddress' => { from: ['descriptionaddress'], split: /\s*[|]\s*/, join: true },
+      'descriptionNeighborhood' => { from: ['descriptionneighborhood'], split: /\s*[|]\s*/, join: true },
       'descriptionStreet' => { from: ['descriptionstreet'], split: /\s*[|]\s*/, join: true },
       'displayRole' => { from: ['displayrole'], split: /\s*[|]\s*/, join: true },
       'donorProvenance' => { from: ['donorprovenance'], split: /\s*[|]\s*/, join: true },

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -404,7 +404,7 @@ fields:
     full_text_searchable: true
 
   descriptionNeighborhood:
-    definition: A neighborhood depicted in or associatd with the work
+    definition: A neighborhood depicted in or associated with the work
     label: Neighborhood
     predicate: local:neighborhood
     full_text_searchable: true


### PR DESCRIPTION
# Summary
-Adds `descriptionNeighborhood` to bulkrax imports&exports
- `descriptionNeighborhood `can now be exported with bulkrax
- `descriptionNeighborhood` can now be imported with bulkrax and display on the workshow page
- the label for `desciptionNeighborhood` is 'Neighborhood'

# Related
https://github.com/UCSCLibrary/dams_project_mgmt/issues/528

# Acceptance Criteria

- [ ] As a user, I can import a csv with the descriptionNeighborhood attribute and see that it is being added in the metadata
- [ ]  As a user, I can see the descriptionNeighborhood field I have imported on the work-show page next to the "Neighborhood" label
- [ ] As a user, I can export works that have the descriptionNeighborhood field filled in, and see the field & value on the exported CSV

## Screenshots

- Show page: 

<img width="762" alt="Screen Shot 2022-04-21 at 8 51 59 AM" src="https://user-images.githubusercontent.com/73361970/164505671-1fa77f4e-19a7-4c78-8c7e-a3a0583676ca.png">


- Export:

<img width="493" alt="Screen Shot 2022-04-21 at 9 04 53 AM" src="https://user-images.githubusercontent.com/73361970/164503942-8b25f035-4f40-4a4d-8e52-02481fb1865d.png">

- Import:

<img width="368" alt="Screen Shot 2022-04-21 at 8 53 24 AM" src="https://user-images.githubusercontent.com/73361970/164504216-188d0e5b-4458-4a8c-a322-930921c700c1.png">

