### PR TITLE
524 Rights statement import export

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -24,9 +24,6 @@ module Bulkrax::HasLocalProcessing
   # Only override rights_statement if the user chose to override them in
   # the Importer form.
   def add_rights_statement
-    # OVERRIDE: Remap rights_statement to rightsStatement. Possibly remove this
-    # after ScoobySnacks is removed (rightsStatement may become rights_statement then)
-    parsed_metadata['rightsStatement'] = parsed_metadata.delete('rights_statement')
     parsed_metadata['rightsStatement'] = [parser.parser_fields['rights_statement']] if override_rights_statement
   end
 


### PR DESCRIPTION
# Summary
Rights statement was not being imported due to a local override that was no longer needed. This PR removes that line and enables `rightsStatement` to be imported & show up on the work show page

# Acceptance Criteria
- [ ] As an admin user, I can import rights statements using Bulkrax
- [ ] As an admin user, I can export rights statements using Bulkrax

# Screenshots

- Parsed metadata:

<img width="616" alt="Screen Shot 2022-04-21 at 3 45 41 PM" src="https://user-images.githubusercontent.com/73361970/164564009-0521b30a-3af3-46e9-b9f2-43f3251f66fc.png">


- Work show page:

<img width="612" alt="Screen Shot 2022-04-21 at 3 46 29 PM" src="https://user-images.githubusercontent.com/73361970/164564027-2528aca2-0e76-459f-9a65-9b09da75d33a.png">

- Exported csv:

<img width="426" alt="Screen Shot 2022-04-21 at 3 54 32 PM" src="https://user-images.githubusercontent.com/73361970/164564366-7e2e806a-f7ef-4975-a95f-39ced5ec953c.png">

