### PR TITLE
update Bulkrax to v3.0.0.beta8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ gem 'scooby_snacks', git: 'https://github.com/UCSCLibrary/ScoobySnacks.git'
 gem 'bulk_ops', git: 'https://github.com/UCSCLibrary/BulkOps.git', branch: 'master'
 
 # Bulkrax
-gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'v3.0.0.beta7-branch'
+gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'v3.0.0.beta8-branch'
 # gem 'bulkrax', path: 'vendor/engines/bulkrax'
 gem 'willow_sword', github: 'notch8/willow_sword'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 6b1ba8c38b0be126f5bec4b77a8c9d90cc741563
-  branch: v3.0.0.beta7-branch
+  revision: 65f9069b0a8aba13c4ca8c14e54d1d9073a04f44
+  branch: v3.0.0.beta8-branch
   specs:
-    bulkrax (3.0.0.beta7)
+    bulkrax (3.0.0.beta8)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)


### PR DESCRIPTION
## Summary 

Bulkrax release notes: https://github.com/samvera-labs/bulkrax/releases/tag/v3.0.0.beta8 

Related issue: https://github.com/UCSCLibrary/dams_project_mgmt/issues/537  