### PR TITLE
Bulkrax v3 release-related updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ gem 'scooby_snacks', git: 'https://github.com/UCSCLibrary/ScoobySnacks.git'
 gem 'bulk_ops', git: 'https://github.com/UCSCLibrary/BulkOps.git', branch: 'master'
 
 # Bulkrax
-gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'v3.0.0.beta8-branch'
+gem 'bulkrax', '~> 3'
 # gem 'bulkrax', path: 'vendor/engines/bulkrax'
 gem 'willow_sword', github: 'notch8/willow_sword'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (3.0.0)
+    bulkrax (3.0.1)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,25 +22,6 @@ GIT
       rubyzip (>= 1.0.0)
 
 GIT
-  remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 65f9069b0a8aba13c4ca8c14e54d1d9073a04f44
-  branch: v3.0.0.beta8-branch
-  specs:
-    bulkrax (3.0.0.beta8)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.1.0)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      simple_form
-
-GIT
   remote: https://github.com/seuros/capistrano-sidekiq.git
   revision: 493ade199ab357ef619f8c7bb4a2bdd8bf653598
   specs:
@@ -216,6 +197,19 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
+    bulkrax (3.0.0)
+      bagit (~> 0.4)
+      coderay
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.1.0)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capistrano (3.14.1)
@@ -1004,7 +998,7 @@ DEPENDENCIES
   blacklight_oai_provider (>= 6.0.0)
   browse-everything
   bulk_ops!
-  bulkrax!
+  bulkrax (~> 3)
   bundler (>= 2)
   byebug
   capistrano

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -36,7 +36,6 @@ Bulkrax::ObjectFactory.class_eval do
       visibility
       work_members_attributes
       admin_set_id
-      member_of_collections_attributes
     ]
     # OVERRIDE: permit controlled field attribute hashes
     ::ScoobySnacks::METADATA_SCHEMA.controlled_field_names.each do |field_name|


### PR DESCRIPTION
# Summary 

- Upgrade to Bulkrax 3.0.1 🎉 
  - [v3.0.0 Release Notes](https://github.com/samvera-labs/bulkrax/releases/tag/v3.0.0) 
  - [v3.0.0 Release Notes](https://github.com/samvera-labs/bulkrax/releases/tag/v3.0.1) 
- Fix `ActiveFedora unknown attribute "member_of_collections_attributes"` error when importing child collections
  - See https://github.com/samvera-labs/bulkrax/pull/508 