### PR TITLE
i519 Local authority should mint on exact match only

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -102,7 +102,11 @@ module Bulkrax::HasLocalProcessing
       next unless subauth_name.present?
 
       subauthority = auth_source.subauthority_for(subauth_name)
-      found_id = subauthority.search(value)&.first&.dig('id')
+      results = subauthority.search(value)
+
+      results.each do |result|
+        found_id = result['id'] if result['label'].parameterize == value.parameterize
+      end
     end
 
     found_id


### PR DESCRIPTION
# Summary 

Related: https://github.com/UCSCLibrary/dams_project_mgmt/issues/519 

Changes: 
- remove fuzzy search
- only return search result if the authority label matches the imported value