### PR TITLE
i517 Fix dateDigitized and datePublished UI error

### DIFF
--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -375,7 +375,6 @@ fields:
     index_itemprop: dateModified
     predicate: DC:modified
 #    index_helper_method: human_readable_date
-    data_type: date
   
   datePublished:
     definition: Date of formal issuance (e.g., publication) of the resource.
@@ -384,7 +383,6 @@ fields:
     index_itemprop: datePublished
     predicate: DC:issued
 #    index_helper_method: human_readable_date
-    data_type: date
   
   description:
     definition: An account of the resource.


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/517 

# Summary 

Remove `data_type: date` metadata schema config for `dateDigitized` and `datePublished` fields, which were [recently converted from date fields into string fields](https://github.com/UCSCLibrary/ucsc-library-digital-collections/commit/dacede13242d5bf14e6ff330b85bf07dfa928f55). 

![Secondary Date Error UCSC Digital Library Collections 2022-05-26 at 2 08 48 PM](https://user-images.githubusercontent.com/32469930/170580642-6ce04a17-26be-4af5-9941-d9ff91c203c3.jpg)
