### PR TITLE
i518 Sanitize controlled field URI values

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -69,8 +69,6 @@ module Bulkrax::HasLocalProcessing
   # Use the imported string values to lookup or create valid ActiveTriples URIs and add them
   # to the Entry's parsed_metadata in the format that the actor stack expects.
   def add_controlled_fields
-    metadata_schema = ::ScoobySnacks::METADATA_SCHEMA
-
     metadata_schema.controlled_field_names.each do |field_name|
       field = metadata_schema.get_field(field_name)
       raw_metadata_for_field = raw_metadata.select { |k, _v| k.match?(/#{field_name.downcase}(_\d+)?/) }
@@ -82,7 +80,7 @@ module Bulkrax::HasLocalProcessing
 
       parsed_metadata.delete(field_name) # replacing field_name with field_name_attributes
       all_values.each_with_index do |value, i|
-        auth_id = value if value.match?(::URI::DEFAULT_PARSER.make_regexp) # assume raw, user-provided URI is a valid authority
+        auth_id = sanitize_controlled_field_uri(value) # assume user-provided URI references a valid authority
         auth_id ||= search_authorities_for_id(field, value)
         auth_id ||= create_local_authority_id(field, value)
         next unless auth_id.present?
@@ -116,5 +114,18 @@ module Bulkrax::HasLocalProcessing
   def create_local_authority_id(field, value)
     local_subauth_name = get_subauthority_for(field: field, authority_name: 'local')
     mint_local_auth_url(local_subauth_name, value) if local_subauth_name.present?
+  end
+
+  def sanitize_controlled_field_uri(value)
+    return unless value.match?(::URI::DEFAULT_PARSER.make_regexp)
+
+    valid_value = value.strip.chomp.sub('https', 'http')
+    valid_value.chop! if valid_value.match?(%r{/$}) # remove trailing forward slash if one is present
+
+    valid_value
+  end
+
+  def metadata_schema
+    ::ScoobySnacks::METADATA_SCHEMA
   end
 end

--- a/spec/models/concerns/has_local_processing_spec.rb
+++ b/spec/models/concerns/has_local_processing_spec.rb
@@ -152,6 +152,49 @@ RSpec.describe Bulkrax::HasLocalProcessing do
         end
       end
     end
+
+    describe '#add_controlled_fields' do
+      context 'when a non-URI value is provided' do
+        before do
+          entry.raw_metadata = { creator: 'Jane Doe' }
+        end
+
+        it 'uses the value to mint a local authority' do
+          entry.add_local
+
+          expect(entry.parsed_metadata.dig('creator_attributes', 0, 'id'))
+            .to include('/authorities/show/local/agents/jane-doe')
+        end
+      end
+
+      describe 'sanitizing user-provided URI values' do
+        context 'when value includes "https"' do
+          before do
+            entry.raw_metadata = { subjectname: 'https://www.example.com/abc123' }
+          end
+
+          it 'replaces it with "http"' do
+            entry.add_local
+
+            expect(entry.parsed_metadata.dig('subjectName_attributes', 0, 'id'))
+              .to eq('http://www.example.com/abc123')
+          end
+        end
+
+        context 'when value includes a trailing slash' do
+          before do
+            entry.raw_metadata = { genre: 'http://www.example.com/abc123/' }
+          end
+
+          it 'removes it' do
+            entry.add_local
+
+            expect(entry.parsed_metadata.dig('genre_attributes', 0, 'id'))
+              .to eq('http://www.example.com/abc123')
+          end
+        end
+      end
+    end
   end
 
   describe '#add_rights_statement' do


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/518 

# Summary

When processing controlled fields on ingest, remove trailing slashes and the "s" from "https" in user-provided URI values