### PR TITLE
i540 Fallback on default thumbnail

### DIFF
--- a/app/helpers/ucsc_thumbnail_helper.rb
+++ b/app/helpers/ucsc_thumbnail_helper.rb
@@ -44,7 +44,7 @@ module UcscThumbnailHelper
 
   def ucsc_thumbnail_tag(doc,image_options)
     url = if image_options[:legacy] || doc.thumbnail_id.nil? || doc.audio?
-            doc.thumbnail_path
+            doc.try(:thumbnail_path) || Hyrax::ThumbnailPathService.call(doc)
           elsif image_options[:square]
             square_thumbnail_url(doc,(image_options[:size] || ucsc_default_thumb_size))
           else


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/540 

## Summary 

Child work thumbnails fallback on Hyrax default. 

The error happened when navigating to a Work's show page that has a child Work who doesn't have a thumbnail. Now, if the child Work doesn't have a thumbnail, it will correctly fallback on the default Hyrax thumbnail. 

![Rel  Work 1 UCSC Digital Library Collections 2022-06-28 at 4 38 43 PM](https://user-images.githubusercontent.com/32469930/176322000-817ff792-1ba7-46e4-ad27-5d04bc52896c.jpg)
