### PR TITLE
i542 Fix ActiveJob::SerializationError when importing ScoobySnacks controlled fields

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_dependency Hyrax::Engine.root.join('app', 'actors', 'hyrax', 'actors', 'create_with_files_actor').to_s
+
+# OVERRIDE FILE from Hyrax 2.9.6
+Hyrax::Actors::CreateWithFilesActor.class_eval do
+  private
+
+  # OVERRIDE: filter out params that are incompatible with ActiveJob
+  def attach_files(files, env)
+    return true if files.blank?
+
+    AttachFilesToWorkJob.perform_later(
+      env.curation_concern,
+      files,
+      # Filter out attributes that cause the following error:
+      # ActiveJob::SerializationError - Only string and symbol hash keys may be serialized as job arguments, but 0 is a Integer
+      # Example param: :subjectName_attributes=>{"0"=>{"id"=>"info:lc/authorities/names/n85279544"}
+      env.attributes.to_h.symbolize_keys.except(*controlled_field_attribute_names)
+    )
+    true
+  end
+
+  def controlled_field_attribute_names
+    attribute_names = []
+
+    ScoobySnacks::METADATA_SCHEMA.controlled_field_names.each { |el| attribute_names << "#{el}_attributes".to_sym }
+
+    attribute_names
+  end
+end


### PR DESCRIPTION
Ref https://github.com/UCSCLibrary/dams_project_mgmt/issues/542 

## Summary 

Override Hyrax actor to filter out ScoobySnacks attrs that cause errors. 

This error occurs when importing a work using Bulkrax that meets the following criteria: 

- Imports at least one controlled field 
- Has a filename in the `filename` column 