### PR TITLE
Make A-Z collection thumbnails same size with css.

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -855,6 +855,10 @@ h5.harmful-language-statement {
     .media:first-child {
         margin-top: 15px;
     }
+    .media-object {
+        height: 100px;
+        object-fit: cover;
+    }
     
 }
 img {


### PR DESCRIPTION
Resolved #420 (hopefully)

- New CSS rules apply a max height to A-Z thumbnails, and fit to cover the 100x100 space.