### PR TITLE
Hide collection descriptions on mobile a-z collections page.

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -855,7 +855,12 @@ h5.harmful-language-statement {
     .media:first-child {
         margin-top: 15px;
     }
-    
+}
+@media all and (max-width: 767px) {
+    #all-collections .media {
+        h4 { margin-top: 25px; }
+        p { display: none; }
+    }
 }
 img {
   border: 2px solid #C0C0C0;


### PR DESCRIPTION
Resolves #375 by hiding collection descriptions and adjusting the spacing of the title in relation to the thumbnail