### PR TITLE
Add visibilty filtering back to A-Z list.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -19,6 +19,7 @@ class CollectionsController < Hyrax::CollectionsController
   def show_all
     builder = Ucsc::CollectionSearchBuilder.new(self).with(params.except(:q))
     @response = repository.search(builder)
+    @collections = @response.documents.select{ |col| ["open","campus"].include?(col.visibility)}
     rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
       []
     end

--- a/app/views/hyrax/collections/show_all.html.erb
+++ b/app/views/hyrax/collections/show_all.html.erb
@@ -14,7 +14,7 @@
 				<h4><%= t("hyrax.collections.az.heading") %></h4>
 			</div>
             
-			<% @response.documents.each do |collection| %>
+			<% @collections.each do |collection| %>
 			<div class="media col-sm-6" data-id="<%= collection.id %>">
 				<div class="media-left">
 					<img alt role="presentation" src="<%= collection.display_image_url(size: '265,') %>" class="media-object" style="width:100px"> </a>


### PR DESCRIPTION
Resolves #382. This PR should be considered to also include [the previous commit](https://github.com/UCSCLibrary/ucsc-library-digital-collections/commit/f58cbffd7a72bb29d62c16a371aaedd6ade2b913) erroneously made to sandbox branch.

Adds visibility filtering back to the A-Z collections page.

It's unclear from testing so far whether or not this is working. From dashboard, if you edit a collection and click the Discovery tab you can set the visibility to "UC Santa Cruz". Then viewing the collection in the dashboard will show its visibility set to "UC Santa Cruz". I haven't been able to find any code responsible for the "UC Santa Cruz" value for visibility, and don't know what its machine name might be.

However, looking at the collections that are currently on production and sandbox and working with campus-only visibility the label reads "Campus Access Only". Clicking edit on them in the dashboard leads to an error. The "Campus Access Only" text can be found in config/locales/hyrax.en.yml, but it doesn't appear that you can set this value or the related "request" value from the dashboard UI, and when these are selected they error out when entering the edit screen. This makes it impossible to currently test very well in our local dev environment.

Aside from this caveat, the sorting of the A-Z page appears to now work correctly with the pager.