### PR TITLE
Remove date uploaded and modified from sort options.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -169,11 +169,6 @@ class CatalogController < ApplicationController
 
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
     ScoobySnacks::BlacklightConfiguration.add_sort_fields(config)
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
-
     
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.


### PR DESCRIPTION
Resolves #367 by removing the relevant sort options from app/controllers/catalog_controller.rb.