### PR TITLE
Fix typo in config/metadata.yml

### DIFF
--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -439,7 +439,7 @@ fields:
     index_itemprop: description
     searchable: true
     linked_to_search: false
-    full_text_searachable: true
+    full_text_searchable: true
     inheritable: true
     collection_inheritable: true
 


### PR DESCRIPTION
Fixes #523 

Makes description full-text searchable, but requires a SOLR re-index for this change to take effect.