### PR TITLE
remove controlled field check, all inheritance works same

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -153,11 +153,7 @@ class Work < ActiveFedora::Base
   end
 
   def inherit_field(field, parent) 
-      if field.controlled?
-        self.send("#{field.name}_attributes=",parent.send(field.name).map{|resource| {id: resource.id}})
-      else
-        self.send("#{field.name}=",parent.send(field.name))
-      end
+    self.send("#{field.name}=",parent.send(field.name))
   end
 
 end


### PR DESCRIPTION
The id check is not necessary here. Inhertance for all fields work the same if no child value is present.