### PR TITLE
Add missing translations to en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,10 @@
 
 en:
   hello: "Hello world"
+  # Hyrax bug makes these strings not appear when defined in hyrax.en.yml
+  hyrax:
+    dashboard:
+      my:
+        heading:
+          collection_type: "Collection Type"
+          visibility: "Visibility"


### PR DESCRIPTION
Fixes #559 by adding string translations to locales/en.yml instead of relying on hyrax default translations.