### PR TITLE
ResourceType uses local vocab instead of purl.org

### DIFF
--- a/app/indexers/controlled_indexer_behavior.rb
+++ b/app/indexers/controlled_indexer_behavior.rb
@@ -58,6 +58,8 @@ module ControlledIndexerBehavior
         response = Net::HTTP.get_response(URI(cleaned_url))
         res = Nokogiri::HTML.parse(response.body)
         label = res.title.split(' - ')[0].strip
+      elsif url.include?("purl.org/dc/dcmitype")
+        label = URI(url).path.split('/').last.gsub!(/([A-Z])/," \\1").strip
       else
         # Smoothly handle some common syntax issues
         if !cleaned_url.is_a? String

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -128,6 +128,14 @@ module Bulkrax::HasLocalProcessing
     valid_value = value.strip.chomp.sub('https', 'http')
     valid_value.chop! if valid_value.match?(%r{/$}) # remove trailing forward slash if one is present
 
+    # We've decided to use the local vocab instead of purl.org
+    if valid_value.include?("purl.org/dc/dcmitype")
+      id = URI(valid_value).path.split('/').last
+      id.gsub!(/([A-Z])/," \\1") # Split camel-case into multiple words
+      id = id.strip.parameterize # then convert to a url format
+      valid_value = "#{CatalogController.root_url}/authorities/show/local/dcmi_types/#{id}"
+    end
+
     valid_value
   end
 

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -172,7 +172,7 @@ fields:
         subauthority: dcmi_types
     facet: true
     inheritable: false
-    input: dropdown
+    input: textbox_autosuggest
 #    multiple: false
 
   rightsStatement:


### PR DESCRIPTION
Resolves #570.

Changes:
1. When indexing labels, purl.org URI's are parsed to grab the label from the end.
2. When importing with bulkrax, purl.org URI's are changed to use local vocabulary instead.
3. Work edit form now uses textbox_autosuggest for ResourceType instead of dropdown.