### PR TITLE
Add javascript to handle item-set metadata when browser is resized.

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -708,8 +708,6 @@ table.work.attributes {
 }
 @media all and (min-width: 768px) {
     .item-set .metadata.mobile { display: none; }
-    .item-set table.attributes,
-    .item-set #collection-metadata { display: inherit; }
 }
 
 /* Download, Share, and Cite buttons */

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -35,7 +35,9 @@
     <span id="hide-more-metadata" onclick="jQuery('.more-metadata').toggle()"><a>Show less information -</a></span>
 </div>
 
+<% if presenter.is_parent %>
 <script>
+// Toggle button for item-set metadata on mobile
 function mobileMetadataToggle() {
     jQuery('table.attributes, #collection-metadata').toggle();
     jQuery('#mobileExpand, #mobileCollapse').toggle();
@@ -45,4 +47,24 @@ function mobileMetadataToggle() {
         jQuery('#show-more-metadata').toggle();
     }
 }
+// Reset the presentation of item-set metadata when the browser is resized.
+// Resizing debounce code courtesy of
+// https://medium.com/@vaibhavar/ui-performance-window-resize-handler-debouncing-2ec5f7432165
+var fnResize = function(){
+    if ($(window).width() > 767) {
+        jQuery('table.attributes, #show-more-metadata, #collection-metadata').show();
+        jQuery('div.more-metadata').hide();
+    } else {
+        jQuery('table.attributes, #show-more-metadata, div.more-metadata, #collection-metadata').hide();
+    }
+}
+var fnResizeCallTimer = null;
+var fnResizeCaller = function(){
+    clearTimeout(fnResizeCallTimer);
+    fnResizeCallTimer = setTimeout(fnResize, 200);
+}
+jQuery(document).ready(function(){
+    jQuery(window).on("resize", fnResizeCaller);
+});
 </script>
+<% end %>


### PR DESCRIPTION
Resolves #598.

- Adds javascript to reset the metadata presentation when the browser is resized, ensuring the mobile presentation or the desktop presentation displays as appropriate.
- Uses a debouncer function to prevent the browser resize happening too quickly/spastically on some browsers.
- Removes the css that was a previous attempt to handle this.