### PR TITLE
Mint local type when purl.org is used and local type doesn't yet exist

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -86,7 +86,7 @@ module Bulkrax::HasLocalProcessing
 
       parsed_metadata.delete(field_name) # replacing field_name with field_name_attributes
       all_values.each_with_index do |value, i|
-        auth_id = sanitize_controlled_field_uri(value) # assume user-provided URI references a valid authority
+        auth_id = sanitize_controlled_field_uri(field, value)
         auth_id ||= search_authorities_for_id(field, value)
         auth_id ||= create_local_authority_id(field, value)
         next unless auth_id.present?
@@ -118,21 +118,30 @@ module Bulkrax::HasLocalProcessing
 
   # @return [String, nil] URI for local authority, or nil if one could not be created
   def create_local_authority_id(field, value)
-    # If purl.org get the label from the end of the URI
-    if value.include?("purl.org/dc/dcmitype")
-      value = URI(value).path.split('/').last
-      value = value.gsub!(/([A-Z])/," \\1").strip # Split camel-case into multiple words
-    end
     local_subauth_name = get_subauthority_for(field: field, authority_name: 'local')
     mint_local_auth_url(local_subauth_name, value) if local_subauth_name.present?
   end
 
-  def sanitize_controlled_field_uri(value)
+  def sanitize_controlled_field_uri(field, value)
+    # We assume user-provided URI references a valid authority
     return unless value.match?(::URI::DEFAULT_PARSER.make_regexp)
-    return if value.include?("purl.org/dc/dcmitype") # Turn purl.org into local vocab
 
     valid_value = value.strip.chomp.sub('https', 'http')
     valid_value.chop! if valid_value.match?(%r{/$}) # remove trailing forward slash if one is present
+
+    # We've decided to use the local vocab instead of purl.org
+    if valid_value.include?("purl.org/dc/dcmitype")
+      id = URI(valid_value).path.split('/').last
+      id.gsub!(/([A-Z])/," \\1") # Split camel-case into multiple words
+      id = id.strip.parameterize # then convert to a url format
+      valid_value = "#{CatalogController.root_url}/authorities/show/local/dcmi_types/#{id}"
+    end
+
+    # Ensure local terms exist before proceeding
+    if valid_value.include?("authorities/show/local")
+      id = URI(valid_value).path.split('/').last
+      valid_value = create_local_authority_id(field, id)
+    end
 
     valid_value
   end


### PR DESCRIPTION
A fix for #570.

- Bulkrax local processing converts purl.org URI's into local vocabulary URI's
- Bulkrax URI sanitizing for local vocabs now checks for the term before proceeding, creating a new term if necessary.