### PR TITLE
608 google analytics

### DIFF
--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -1,0 +1,24 @@
+<%#= Overwritten from Hyrax 2.9.6
+  #  Complete rewrite to use new gtag instead of ga.js
+  #  Manually adding the legacy UA ID for now %>
+
+<%# Only track on production %>
+<% if Hyrax.config.analytics && Hyrax.config.google_analytics_id? && Rails.env.development? %>
+<% tracking_id = Hyrax.config.google_analytics_id %>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= tracking_id %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '<%= tracking_id %>', {"groups":"default","anonymize_ip":true,"link_attribution":true,"allow_ad_personalization_signals":false});
+  gtag('config', 'UA-2259271-24',   {"groups":"default","anonymize_ip":true,"link_attribution":true,"allow_ad_personalization_signals":false});
+</script>
+<% else %>
+<!-- Enabled in configuration: <%= Hyrax.config.analytics %>-->
+<!-- ID: <%= Hyrax.config.google_analytics_id %> -->
+<!-- Google Analytics is disabled on non-production environments -->
+<!-- End Google Analytics -->
+<% end %>

--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -3,7 +3,7 @@
   #  Manually adding the legacy UA ID for now %>
 
 <%# Only track on production %>
-<% if Hyrax.config.analytics && Hyrax.config.google_analytics_id? && Rails.env.development? %>
+<% if Hyrax.config.analytics && Hyrax.config.google_analytics_id? && Rails.env.production? %>
 <% tracking_id = Hyrax.config.google_analytics_id %>
 
 <!-- Google tag (gtag.js) -->

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -45,7 +45,7 @@ Hyrax.config do |config|
   config.analytics = true
 
   # Google Analytics tracking ID to gather usage statistics
-  config.google_analytics_id = 'UA-2259271-24'
+  config.google_analytics_id = 'G-9SL44KPY4G'
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by


### PR DESCRIPTION
Resolves #608.

- Changes the Google Analytics ID in hyrax configuration to our new GA4 tag.
- Overwrites Hyrax's _ga.html.erb partial to use the new gtag script instead of the legacy ga.js.
- Manually adds our old UA tag to the partial to ensure data continuity.