### PR TITLE
507 facet az

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -871,18 +871,31 @@ h5.harmful-language-statement {
     display: flex;
     flex-flow: row wrap;
     margin-bottom: 30px;
+    .media { margin-bottom: 30px; }
     .media:first-child {
         margin-top: 15px;
     }
+    .media-body { position: relative; }
+    p.media-description { margin: 0 0 25px; }
+    .media-count {
+        position: absolute;
+        bottom: -10px;
+        font-weight: bold;
+    }
     .media-object {
-        height: 100px;
+        height: 150px;
         object-fit: cover;
     }
 }
 @media all and (max-width: 767px) {
     #all-collections .media {
-        h4 { margin-top: 25px; }
+        margin-left: 15px;
         p { display: none; }
+        h4 {
+            display: table-cell;
+            height: 150px;
+            vertical-align: middle;
+        }
     }
 
 }
@@ -1281,7 +1294,9 @@ all and (min-width: 992px) and (-webkit-transform-3d) {
         }
         #facet-panel-collapse {
             color: #fff;
+            background-color: #20477d;
             border-top: none;
+            .input-group { margin: 8px; }
             .panel-default > .panel-heading {
                 border-radius: 0;
                 background-color: #20477d;

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,26 +1,49 @@
 class CollectionsController < Hyrax::CollectionsController
   layout :resolve_layout
   self.presenter_class = Ucsc::CollectionPresenter
-  skip_load_and_authorize_resource :only => :show_all
+  skip_load_and_authorize_resource :only => :index
   load_and_authorize_resource except: [:index, :create], instance_name: :collection
 
+  # Limit facets and per page results on A-Z
+  before_action only: :index do
+    self.blacklight_config.facet_fields.slice!('creator_sim', 'subjectName_sim', 'subjectPlace_sim', 'subjectTopic_sim')
+    self.blacklight_config.default_per_page = 10
+  end
+  # Restore defaults for collection landing page, remove 'collection' facet
+  before_action only: :show do
+    self.class.copy_blacklight_config_from(::CatalogController)
+    # hide collection facet when searching within one collection
+    self.blacklight_config.facet_fields.delete('ancestor_collection_titles_ssim')
+  end
+
   def resolve_layout
-    return "hyrax" if action_name == "show_all"
+    return "hyrax" if action_name == "index"
     query_collection_members
     return "collection_with_subcollections" if @subcollection_count > 0
     "hyrax"
   end
 
-  # This makes the search box on a collection page lead back to the same collection page
-  # instead of the search results page
+  # Use collections controller for facet links
   def search_action_url options = {}
-    url_for(options.reverse_merge(action: 'index', controller: 'catalog').deep_merge(f: {"ancestor_collection_titles_ssim" => Array(@collection.title)}))
+    if action_name == "index"
+      url_for(options.reverse_merge(action: "index", controller: 'collections'))
+    elsif action_name == "show"
+      # Using collections#show, if a facet value is clicked that comes from a member work
+      # the search fails and goes to homepage with a not authorized error.
+      # Using catalog#index the facets work, but its independent of keyword searching.
+      url_for(options.reverse_merge(action: 'index', controller: 'catalog').deep_merge(f: {"ancestor_collection_titles_ssim" => Array(@collection.title)}))
+    else
+      super
+    end
   end
-  def show_all
-    builder = Ucsc::CollectionSearchBuilder.new(self).with(params.except(:q))
+
+  def index
+    builder = Ucsc::CollectionSearchBuilder.new(self).with(params)
     @response = repository.search(builder)
     @collections = @response.documents.select{ |col| ["open","campus"].include?(col.visibility)}
-    rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
-      []
-    end
+    @presenter = presenter_class.new(current_ability, @collections)
+  rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
+    []
+  end
+
 end

--- a/app/presenters/ucsc/collection_presenter.rb
+++ b/app/presenters/ucsc/collection_presenter.rb
@@ -24,5 +24,10 @@ module Ucsc
       return "" unless (builder_id = solr_document.representative_id || solr_document.thumbnail_id)
       Hyrax.config.iiif_image_url_builder.call(builder_id,"nil",size,region)
     end
+
+    # Override to be able to pass parameters from A-Z page
+    def total_viewable_items(id, current_ability)
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").accessible_by(current_ability).count
+    end
   end
 end

--- a/app/views/hyrax/collections/_facets.html.erb
+++ b/app/views/hyrax/collections/_facets.html.erb
@@ -1,14 +1,21 @@
 <%#= Custom file %>
-<% if has_facet_values?  %>
-<div id="facets" class="facets sidenav">
-  <div class="top-panel-heading panel-heading">
-    <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
-      <span>Show Filters <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></span>
-    </button>
-  </div>
-  <div id="facet-panel-collapse" class="collapse panel-group">
-    <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
-    <%= render_facet_partials %>
+<div class="hyc-blacklight hyc-bl-search hyc-body">
+  <div id="facets" class="facets sidenav">
+    <div class="top-panel-heading panel-heading">
+      <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
+        <span>Show Filters <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></span>
+      </button>
+    </div>
+    <div id="facet-panel-collapse" class="collapse panel-group">
+      <% if params[:action] == "show" %>
+        <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
+      <% elsif params[:action] == "index" %>
+        <%# Search A-Z Collections %>
+        <%= render 'search_form_az' %>
+      <% end %>
+      <% if has_facet_values?  %>
+        <%= render_facet_partials %>
+      <% end %>
+    </div>
   </div>
 </div>
-<% end %>

--- a/app/views/hyrax/collections/_facets.html.erb
+++ b/app/views/hyrax/collections/_facets.html.erb
@@ -3,7 +3,7 @@
   <div id="facets" class="facets sidenav">
     <div class="top-panel-heading panel-heading">
       <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
-        <span>Show Filters <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></span>
+        <span>Search &amp; Filter <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></span>
       </button>
     </div>
     <div id="facet-panel-collapse" class="collapse panel-group">

--- a/app/views/hyrax/collections/_search_form_az.html.erb
+++ b/app/views/hyrax/collections/_search_form_az.html.erb
@@ -1,0 +1,21 @@
+<%# Copied from Hyrax 2.9.6 app/views/hyrax/my/_search_form %>
+<%# text_field_tag placeholder is the only modification on this file %>
+<%= form_tag search_action_url, method: :get, class: "search-query-form form-horizontal search-form", role: "search" do %>
+
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <div class="form-group">
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
+    </label>
+
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.collections.az.search") %>
+
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div>
+    </div><!-- /.input-group -->
+  </div><!-- /.form-group -->
+<% end %>

--- a/app/views/hyrax/collections/_search_form_az.html.erb
+++ b/app/views/hyrax/collections/_search_form_az.html.erb
@@ -1,21 +1,16 @@
 <%# Copied from Hyrax 2.9.6 app/views/hyrax/my/_search_form %>
-<%# text_field_tag placeholder is the only modification on this file %>
+<%# text_field_tag placeholder updated, label & wrapper divs removed, all_fields added %>
 <%= form_tag search_action_url, method: :get, class: "search-query-form form-horizontal search-form", role: "search" do %>
 
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
-  <div class="form-group">
-    <label class="control-label col-sm-3" for="search-field-header">
-      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
-    </label>
+  <input type="hidden" name="search_field" value="all_fields"/>
+  <div class="input-group">
+    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.collections.az.search") %>
 
-    <div class="input-group">
-      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.collections.az.search") %>
-
-      <div class="input-group-btn">
-        <button type="submit" class="btn btn-primary" id="search-submit-header">
-          <%= t('hyrax.search.button.html') %>
-        </button>
-      </div>
-    </div><!-- /.input-group -->
-  </div><!-- /.form-group -->
+    <div class="input-group-btn">
+      <button type="submit" class="btn btn-primary" id="search-submit-header">
+        <%= t('hyrax.search.button.html') %>
+      </button>
+    </div>
+  </div><!-- /.input-group -->
 <% end %>

--- a/app/views/hyrax/collections/_show_collection_without_subcollections.html.erb
+++ b/app/views/hyrax/collections/_show_collection_without_subcollections.html.erb
@@ -59,11 +59,7 @@
 
     <!-- Search bar -->
     <%#= Removed row class and moved search_form render to custom _facets partial %>
-    <div class="hyc-blacklight hyc-bl-search hyc-body">
-      <div>
-        <%= render 'facets' %>
-      </div>
-    </div>
+    <%= render 'facets' %>
   </div>
 
   <div class="col-sm-8">
@@ -71,18 +67,18 @@
 
     <%# This is a hacky replacement for the constraints box,
       # which wasn't working on the collection page  %>
-    <% if params['q'].present? %>
+    <% if params['cq'].present? %>
       <div id="appliedParams" class="clearfix constraints-container">
         <span class="constraints-label">Filtering by:</span>
         <span class="btn-group appliedFilter constraint filter filter-creator_sim">
           <span class="constraint-value btn btn-sm btn-default btn-disabled">
-            <span class="filterValue" title="<%= params['q']%>"><%= params['q'] %></span>
+            <span class="filterValue" title="<%= params['cq']%>"><%= params['cq'] %></span>
           </span>
           <%# The following line opens a security hole, if users add parameters that have special meaning for url_for%>
           <%# Instead, the parameters should be permitted properly in the controller before being used here %>
-          <a class="btn btn-default btn-sm remove dropdown-toggle" href="<%= url_for(params.except(:q).to_unsafe_h) %>">
+          <a class="btn btn-default btn-sm remove dropdown-toggle" href="<%= url_for(params.except(:cq).to_unsafe_h) %>">
             <span class="glyphicon glyphicon-remove"></span>
-            <span class="sr-only">Remove constraint "<%= params['q'] %>"</span>
+            <span class="sr-only">Remove constraint "<%= params['cq'] %>"</span>
           </a>
         </span>
       </div>

--- a/app/views/hyrax/collections/index.html.erb
+++ b/app/views/hyrax/collections/index.html.erb
@@ -1,13 +1,24 @@
 <%#= Custom file for A-Z collections page %>
 <div itemscope itemtype="http://schema.org/CollectionPage">
 
-  <div class="row">
-    <div class="col-md-12">
+	<div class="row">
+		<div class="col-sm-12">
+			<header id="collection-description" class="row">
+				<div class="hyc-title"><h1><%= t("hyrax.collections.az.title") %></h1></div>
+				<p><%= t("hyrax.collections.az.description") %></p>
+			</header>
+		</div>
+	</div>
 
-		<header id="collection-description" class="row">
-			<div class="hyc-title"><h1><%= t("hyrax.collections.az.title") %></h1></div>
-			<p><%= t("hyrax.collections.az.description") %></p>
-		</header>
+  <div class="row">
+  	<div class="col-sm-4">
+      <%= render 'facets' %>
+  	</div>
+
+    <div class="col-sm-8">
+
+    <%= render 'did_you_mean' %>
+		<%= render 'constraints' %>
 
 		<div id="all-collections" class="collections row">
 			<div class="hyc-blacklight hyc-bl-title col-xs-12">
@@ -15,7 +26,7 @@
 			</div>
             
 			<% @collections.each do |collection| %>
-			<div class="media col-sm-6" data-id="<%= collection.id %>">
+			<div class="media" data-id="<%= collection.id %>">
 				<div class="media-left">
 					<img alt role="presentation" src="<%= collection.display_image_url(size: '265,') %>" class="media-object" style="width:100px"> </a>
 				</div>
@@ -23,7 +34,8 @@
 					<h4 class="media-heading">
 						<a href="/collections/<%= collection.id %>?locale=en"><%= collection.title.first %></a>
 					</h4>
-					<p><%= collection.description.first.truncate(160) if collection.description.present? %></p>
+					<p><%= collection.description.first if collection.description.present? %></p>
+					<p><%= collection.extent.first if collection.extent.present? %></p>
         </div>
 			</div>
 			<% end %>

--- a/app/views/hyrax/collections/index.html.erb
+++ b/app/views/hyrax/collections/index.html.erb
@@ -22,20 +22,30 @@
 
 		<div id="all-collections" class="collections row">
 			<div class="hyc-blacklight hyc-bl-title col-xs-12">
-				<h4><%= t("hyrax.collections.az.heading") %></h4>
+				<%# Switch title based on search params and number of results %>
+				<% if params['q'] || params['f'] %>
+					<% results = @response.response['numFound'] %>
+					<% if results == 1 %>
+						<h4>1 result</h4>
+					<% else %>
+						<h4><%= results %> results</h4>
+					<% end %>
+				<% else # print the non-search A-Z heading %>
+					<h4><%= t("hyrax.collections.az.heading") %></h4>
+				<% end %>
 			</div>
-            
+
 			<% @collections.each do |collection| %>
 			<div class="media" data-id="<%= collection.id %>">
 				<div class="media-left">
-					<img alt role="presentation" src="<%= collection.display_image_url(size: '265,') %>" class="media-object" style="width:100px"> </a>
+					<img alt role="presentation" src="<%= collection.display_image_url(size: '265,') %>" class="media-object" style="width:150px"> </a>
 				</div>
 				<div class="media-body">
 					<h4 class="media-heading">
 						<a href="/collections/<%= collection.id %>?locale=en"><%= collection.title.first %></a>
 					</h4>
-					<p><%= collection.description.first if collection.description.present? %></p>
-					<p><%= collection.extent.first if collection.extent.present? %></p>
+					<p class="media-description"><%= collection.description.first if collection.description.present? %></p>
+					<p class="media-count"><%= @presenter.total_viewable_items(collection.id, current_ability) %> items</p>
         </div>
 			</div>
 			<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -108,7 +108,7 @@ en:
       az:
         title: "About the UCSC Library Digital Collections"
         description: "Explore over 100,000 digitized items from UCSC Special Collections & Archives. This site is a living database with new photographs, documents, maps, audio and video added regularly. While only a small fraction of the Library’s archival collections are digitized, you can learn more about the unique archives from which these items originate in the Collection Guides linked to each item."
-        heading: "A-Z List of Collections"
+        heading: "All Collections"
         search: "Search for a collection..."
     collection_type:
       default_title: "Collection"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -109,6 +109,7 @@ en:
         title: "About the UCSC Library Digital Collections"
         description: "Explore over 100,000 digitized items from UCSC Special Collections & Archives. This site is a living database with new photographs, documents, maps, audio and video added regularly. While only a small fraction of the Library’s archival collections are digitized, you can learn more about the unique archives from which these items originate in the Collection Guides linked to each item."
         heading: "A-Z List of Collections"
+        search: "Search for a collection..."
     collection_type:
       default_title: "Collection"
     division:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   get '/admin/workflows(.:format)', to: 'admin/workflows#index'
 
-  resources :collections, only: :show do # public landing show page
+  resources :collections, only: [:index, :show] do # public landing show page
     member do
       get 'page/:page', action: :index
       get 'facet/:id', action: :facet, as: :dashboard_facet
@@ -47,7 +47,6 @@ Rails.application.routes.draw do
 
   post 'concern/works/:id/email' => 'hyrax/works#send_email'
   get 'concern/works/:id/email' => 'hyrax/works#show'
-  get 'collections', to: 'collections#show_all'
   authenticate :user, lambda { |u| u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end


### PR DESCRIPTION
Resolves #507 Implementing faceting and searching on A-Z Collections.

1. Update config/routes.rb to use the rails native Collections#index instead of a custom #show_all action.
2. In app/controllers/collections_controller.rb:
  - Update  #show_all references to #index.
  - Configure blacklight differently for #show vs #index using rails before_action calls.
  - Switch search_action_url based on current action.
  - Instantiate a presenter for the index page.
3. In our collection presenter override the parent method to get total items so that a specific collection can be passed in.
4. Restructure _facets.html.erb partial to fit both index and show pages.
5. Add _search_form_az.html.erb partial based on the partial for hyrax my collections dashboard page.
6. In the collection landing page, use 'cq' for the contraints parameter instead of 'q'.
7. Move show_all.html.erb to index.html.erb with changes to support search/facet.
8. Text updates in config/locales/hyrax.en.yml