### PR TITLE
Available locales includes only English

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,7 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
+  config.i18n.available_locales = [:en]
   config.i18n.default_locale = :'en'
   config.i18n.enforce_available_locales = false
 

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -83,6 +83,9 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
+  config.i18n.available_locales = [:en]
+  config.i18n.default_locale = :'en'
+  config.i18n.enforce_available_locales = false
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,6 +78,9 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
+  config.i18n.available_locales = [:en]
+  config.i18n.default_locale = :'en'
+  config.i18n.enforce_available_locales = false
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
Resolves #404 

Adds `config.i18n.available_locales = [:en]` in the application config. Standardizes the internationalization configuration across sandbox, staging, and production.