### PR TITLE
Image size now 1000 default on work show page

### DIFF
--- a/app/presenters/ucsc/work_show_presenter.rb
+++ b/app/presenters/ucsc/work_show_presenter.rb
@@ -22,7 +22,7 @@ module Ucsc
     end
 
     # We should delegate this to the solrDocument, which should have it already indexed (for works at least).
-    def display_image_url(size="800,")
+    def display_image_url(size="1000,")
       if representative_id
         return "" unless current_ability.can?(:read, representative_id)
         representative_image = SolrDocument.find(representative_id)


### PR DESCRIPTION
Resolves #652 by changing the default from 800 to 1000 in the work presenter. This is a temporary stop-gap to deal with the 800px derivatives sometimes having missing pieces.