### PR TITLE
404 translations

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,13 +80,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-  config.i18n.available_locales = [:en]
-  config.i18n.default_locale = :'en'
-  config.i18n.enforce_available_locales = false
-
   # Send deprecation notices to registered listeners.
   #config.active_support.deprecation = :silence
   config.active_support.report_deprecations = false

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -80,13 +80,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-  config.i18n.available_locales = [:en]
-  config.i18n.default_locale = :'en'
-  config.i18n.enforce_available_locales = false
-
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -75,13 +75,6 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_options = {from: 'no-reply@digitalcollections-staging.library.ucsc.edu'}
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-  config.i18n.available_locales = [:en]
-  config.i18n.default_locale = :'en'
-  config.i18n.enforce_available_locales = false
-
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 

--- a/config/initializers/locales.rb
+++ b/config/initializers/locales.rb
@@ -1,0 +1,6 @@
+# Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+# the I18n.default_locale when a translation cannot be found).
+Rails.application.config.i18n.fallbacks = true
+Rails.application.config.i18n.available_locales = [:en]
+Rails.application.config.i18n.default_locale = :'en'
+Rails.application.config.i18n.enforce_available_locales = true

--- a/public/500.html
+++ b/public/500.html
@@ -58,9 +58,9 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>Sorry, we can't find that page.</h1>
     </div>
-    <p>You may <a href="https://guides.library.ucsc.edu/digitalcollections/ask">report this problem</a> or <a href="/">return to the homepage</a>.</p>
+    <p><a href="/">Go to the homepage</a></p>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -60,7 +60,7 @@
     <div>
       <h1>We're sorry, but something went wrong.</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>You may <a href="https://guides.library.ucsc.edu/digitalcollections/ask">report this problem</a> or <a href="/">return to the homepage</a>.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Resolves #404

1. Our desired configuration for Rails I18n gem is consistent across environments, so the config setup moved from environment specific files into its own file under config/initializers.
2. The error page for unsupported languages (and all other 500 errors) now has friendlier language and link back to the homepage.