### PR TITLE
Fix deploy wait script

### DIFF
--- a/stack_car/run-tests-when-ready.sh
+++ b/stack_car/run-tests-when-ready.sh
@@ -4,13 +4,13 @@
 # We wait up to ten minutes for the test webapp to come up, though
 # it rarely takes that long unless it needs to reinstall the 
 # entire gemset
-wait-for-services.sh localhost:3000 -t 600
+./wait-for-services.sh localhost:3000 -t 600
 #
 # The other services should definitely be online by now,
 # but we wait up to three minutes for each just in case. 
-wait-for-services.sh db:3306 -t 180
-wait-for-services.sh repo:8080 -t 180
-wait-for-services.sh index:8983 -t 180
+./wait-for-services.sh db:3306 -t 180
+./wait-for-services.sh repo:8080 -t 180
+./wait-for-services.sh index:8983 -t 180
 #
 # This command runs all tests in the "spec" folder 
 # except the smoke tests (which are run separately)


### PR DESCRIPTION
Fixes these errors in jenkins deployment:
```
stack_car/run-tests-when-ready.sh: line 7: wait-for-services.sh: command not found
stack_car/run-tests-when-ready.sh: line 11: wait-for-services.sh: command not found
stack_car/run-tests-when-ready.sh: line 12: wait-for-services.sh: command not found
stack_car/run-tests-when-ready.sh: line 13: wait-for-services.sh: command not found
```