### PR TITLE
Fix permissions issues in deployment pipeline.

### DIFF
--- a/stack_car/docker-compose.yml
+++ b/stack_car/docker-compose.yml
@@ -16,7 +16,9 @@ x-app: &app
     - assets:/app/samvera/hyrax-webapp/public/assets
     - cache:/app/samvera/hyrax-webapp/tmp/cache
     - gems:/srv/bundle:Z
+    - ../dams_derivatives:/dams_derivatives
     - ../example_media:/srv/hycruz/public/example_media
+    - ..:/app/samvera/hyrax-webapp
 
 services:
   web:


### PR DESCRIPTION
1. Adds the application volume back to docker-compose to enable development without rebuilds.
2. Fixes the permissions issues in deployment by manually updating them in the Jenkinsfile.
3. Breaks shell commands into multiple lines for easier reading.
4. Removes branch variable from most commands now that docker-compose no longer requires it.