### PR TITLE
Index audio? and image? methods to improve performance

### DIFF
--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -2,6 +2,7 @@
 # 
 class FileSetIndexer < Hyrax::FileSetIndexer
   include AncestorCollectionBehavior
+  include WorkTypeIndexerBehavior
   def generate_solr_document
     super.tap do |solr_doc|
       # Indexing the original file may no longer be necessary
@@ -28,6 +29,9 @@ class FileSetIndexer < Hyrax::FileSetIndexer
       else
         solr_doc["visibility_ssi"] = "restricted"
       end
+
+      # index booleans for the type of fileset, which helps determine the work type
+      solr_doc = index_fileset_type(solr_doc)
     end
   end
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -17,6 +17,9 @@ class WorkIndexer < Hyrax::WorkIndexer
   include AncestorCollectionBehavior
   include SortableFieldIndexerBehavior
 
+  # Index the type of work, ie image vs audio, so it can be presented correctly
+  include WorkTypeIndexerBehavior
+
   include Ucsc
 
   # This is the main method to generate a solr document from a fedora object.
@@ -30,6 +33,9 @@ class WorkIndexer < Hyrax::WorkIndexer
       # work show pages, iiif manifests, etc
       solr_doc['file_set_ids_ssim'] = object.file_set_ids
       solr_doc['member_ids_ssim'] = object.ordered_member_ids
+
+      # index booleans for the type of work, which helps determine details for the presentation
+      solr_doc = index_work_type(solr_doc)
 
       # This block collects the representative images of all
       # child image filesets and child image works and indexes them under 'hasRelatedImage_ssim'

--- a/app/indexers/work_type_indexer_behavior.rb
+++ b/app/indexers/work_type_indexer_behavior.rb
@@ -1,0 +1,37 @@
+# Indexes booleans describing the type of work, so the presenter can quickly
+# determine how to display the work on show and search results pages
+module WorkTypeIndexerBehavior
+  extend ActiveSupport::Concern
+
+  def index_work_type(doc)
+    return doc unless object.representative_id
+    fs = FileSet.find(object.representative_id)
+
+    doc["audio?_bsi"] = false
+    doc["audio?_bsi"] = true if FileSet.audio_mime_types.include? fs.mime_type
+    doc["audio?_bsi"] ||= true if object.resourceType.any?{|restype| ["audio","sound"].include? restype.to_s.downcase}
+    doc["audio?_bsi"] ||= true if object.file_set_ids.any?{|id| SolrDocument.find(id).audio?}
+    doc["audio?_bsi"] ||= true if object.member_work_ids.present? && object.member_work_ids.all?{|id| SolrDocument.find(id).audio?}
+
+    doc["image?_bsi"] = false
+    doc["image?_bsi"] = true if FileSet.image_mime_types.include? fs.mime_type
+    doc["image?_bsi"] ||= true if object.resourceType.any?{|restype| ["photograph","image","picture","photo"].include? restype.to_s.downcase}
+    doc["image?_bsi"] ||= true if object.file_set_ids.any?{|id| SolrDocument.find(id).image?}
+    doc["image?_bsi"] ||= true if object.member_work_ids.present? && object.member_work_ids.all?{|id| SolrDocument.find(id).image?}
+
+    return doc
+  end
+
+  def index_fileset_type(doc)
+    doc["audio?_bsi"] = false
+    doc["audio?_bsi"] = true if FileSet.audio_mime_types.include? object.mime_type
+    doc["audio?_bsi"] ||= true if object.resourceType.any?{|restype| ["audio","sound"].include? restype.to_s.downcase}
+
+    doc["image?_bsi"] = false
+    doc["image?_bsi"] = true if FileSet.image_mime_types.include? object.mime_type
+    doc["image?_bsi"] ||= true if object.resourceType.any?{|restype| ["photograph","image","picture","photo"].include? restype.to_s.downcase}
+
+    return doc
+  end
+
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -141,17 +141,26 @@ class SolrDocument
     return false unless ["audio","video","image"].include? type.to_s
   end
 
+  # After a reindex is complete, the default should be changed from audio_legacy? to false
   def audio?
-    #todo index this
+    fetch('audio?_bsi', audio_legacy?)
+  end
+
+  # This method can be removed after the next re-index is completed
+  def audio_legacy?
     return true if FileSet.audio_mime_types.include? mime_type
     return true if resourceType.any?{|restype| ["audio","sound"].include? restype.to_s.downcase}
     return true if file_set_ids.any?{|id| SolrDocument.find(id).audio?}  
     member_work_ids.present? && member_work_ids.all?{|id| SolrDocument.find(id).audio?}
   end
- 
+
+  # After a reindex is complete, the default should be changed from image_legacy? to false
   def image?
-    #todo index this
-    return true if super
+    fetch('image?_bsi', image_legacy?)
+  end
+
+  # This method can be removed after the next re-index is completed
+  def image_legacy?
     return true if FileSet.image_mime_types.include? mime_type
     return true if resourceType.any?{|restype| ["photograph","image","picture","photo"].include? restype.to_s.downcase}
     return true if file_set_ids.any?{|id| SolrDocument.find(id).image?}  


### PR DESCRIPTION
Resolves #656.

- Indexes audio? and image? methods to improve performance on search results, collection landing pages, and work show pages.
- Leaves legacy methods for those values to preserve functionality while re-indexing is incomplete.

To see the performance improvements, we will need to re-index the site. After that is completed the legacy methods can be removed.