### PR TITLE
392 labels

### DIFF
--- a/app/assets/stylesheets/ucsc.scss.erb
+++ b/app/assets/stylesheets/ucsc.scss.erb
@@ -1168,10 +1168,6 @@ all and (min-width: 992px) and (-webkit-transform-3d) {
     }
 }
 
-
-
-
-
 /* Results Sort and Per Page */
 .hyc-bl-sort,
 #sortAndPerPage {
@@ -1242,6 +1238,10 @@ all and (min-width: 992px) and (-webkit-transform-3d) {
     }
     #facet-panel-collapse {
         padding-right: 0;
+        .facet-panel-group {
+            display: flex;
+            flex-direction: column;
+        }
         .panel-default > .panel-heading {
             background-color: #fff;
             color: #757575;
@@ -1253,6 +1253,13 @@ all and (min-width: 992px) and (-webkit-transform-3d) {
             border-radius: 0;
             margin-top: 20px;
         }
+        .panel.blacklight-series_sim { order: 1; }
+        .panel.blacklight-subjectplace_sim { order: 2; }
+        .panel.blacklight-subjecttopic_sim { order: 3; }
+        .panel.blacklight-subjectname_sim { order: 4; }
+        .panel.blacklight-creator_sim { order: 5; }
+        .panel.blacklight-resourcetype_sim { order: 6; }
+        .panel.blacklight-ancestor_collection_titles_ssim { order: 7; }
         /* Swap the glyphicons per style guide */
         .panel-heading.collapse-toggle .panel-title::after {
             content: "\e113";

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -13,7 +13,9 @@
     </h2>
   </div>
   <div id="facet-panel-collapse" class="collapse panel-group">
-    <%= render_facet_partials %>
+    <div class="facet-panel-group">
+      <%= render_facet_partials %>
+    </div>
   </div>
 </div>
 <% end %>

--- a/app/views/hyrax/collections/_facets.html.erb
+++ b/app/views/hyrax/collections/_facets.html.erb
@@ -14,7 +14,9 @@
         <%= render 'search_form_az' %>
       <% end %>
       <% if has_facet_values?  %>
-        <%= render_facet_partials %>
+        <div class="facet-panel-group">
+          <%= render_facet_partials %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -161,7 +161,7 @@ fields:
   
   resourceType:
     definition: 'General nature or type of the resource (e.g., image, text, etc.). Does not capture aboutness. '
-    label: Type
+    label: Resource Type
     searchable: true
     predicate: DC:type
     display_groups: 
@@ -210,7 +210,7 @@ fields:
 
   series:
     definition: A related resource in which the described resource is physically or logically included.
-    label: Series Title
+    label: Series
     predicate: opaque:seriesName
     display_groups: 
       - primary
@@ -242,7 +242,7 @@ fields:
   
   subjectName:
     definition: A name of the person that the resource is about.
-    label: Subject (People)
+    label: People
     predicate: FOAF:name
     vocabularies:
       - authority: loc
@@ -265,7 +265,7 @@ fields:
   
   subjectPlace:
     definition: Spatial characteristics of the resource.
-    label: Subject (Place)
+    label: Place
     predicate: DC:spatial
     vocabularies: 
       - authority: geonames
@@ -315,7 +315,7 @@ fields:
         subauthority: subjects
       - authority: local
         subauthority: agents
-    facet: true
+    facet: false
     searchable: true
     full_text_searchable: true
     index_itemprop: about
@@ -330,7 +330,7 @@ fields:
   
   subjectTopic:
     definition: The topic of the resource.
-    label: Subject (Topic)
+    label: Topic
     predicate: DC:subject
     vocabularies: 
       - authority: loc


### PR DESCRIPTION
Resolves [392 - Update facet order & label](https://github.com/UCSCLibrary/ucsc-library-digital-collections/issues/392)

- Updates labels in config/metadata.yml to match data dictionary.
- Also in metadata.yml, sets subjectTitle facetable to false.
- Adds a new wrapper to facet groups in the facets view partials.
- Uses that wrapper to set the display order via flexbox css.